### PR TITLE
addressing issue #129: indicate that a user should input text, use "enter" rather than "type" or "input"

### DIFF
--- a/.vale/styles/RedHat/text-enter.yml
+++ b/.vale/styles/RedHat/text-enter.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' rather than '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#text-entry
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+  type|input: enter


### PR DESCRIPTION
HI @themr0c this is my attempt to address https://github.com/redhat-documentation/vale-at-red-hat/issues/129. I am not sure if it is the correct syntax