### PR TITLE
fix: lower severity of the ThereIs rule

### DIFF
--- a/.vale/styles/RedHat/ThereIs.yml
+++ b/.vale/styles/RedHat/ThereIs.yml
@@ -2,7 +2,7 @@
 extends: existence
 message: "Don't start a sentence with '%s'"
 ignorecase: true
-level: error
+level: suggestion
 source: write-good
 raw:
   - '(?:^[^\w]*|[;-]\s)There\b\s(is|are)\b'


### PR DESCRIPTION
This rule originates from write-good. Sentences starting with There is are common in the Supplementary Style Guide.