### PR TITLE
chore: prepare for Antora 3.0.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ const { parallel, series, src, watch } = require('gulp')
 const yaml = require('js-yaml')
 
 const playbookFilename = 'antora-playbook-for-development.yml'
-const playbook = yaml.safeLoad(fs.readFileSync(playbookFilename, 'utf8'))
+const playbook = yaml.load(fs.readFileSync(playbookFilename, 'utf8'))
 const outputDir = (playbook.output || {}).dir || './build/site'
 const serverConfig = { name: 'Preview Site', livereload, host: '0.0.0.0', port: 4000, root: outputDir }
 const antoraArgs = ['--playbook', playbookFilename]


### PR DESCRIPTION
Necessary gulpfile.js update before publishing new che-docs container with Antora 3.0.0. See: https://github.com/eclipse/che-docs/pull/2213/

Antora 2.3 will enter maintenance on January 25, 2022 and reach end of life (EOL) on February 25, 2022. See: https://docs.antora.org/antora/latest/whats-new/#antora-2-3-eol


