### PR TITLE
feat: input|type: enter (followed by the text to enter in monospace)

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -13,6 +13,7 @@ client-side
 Cloud
 code
 functionality
+input
 recommend
 refer to
 roll out
@@ -26,6 +27,7 @@ this clause, that is restrictive
 this clause which is nonrestrictive
 through
 thru
+type
 user space
 user-space
 userspace

--- a/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
@@ -1,6 +1,7 @@
 archive
 cloud
 compress
+enter
 functions
 repository
 see

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -23,6 +23,7 @@ swap:
   Cloud: cloud
   code: write
   functionality: functions # IBM
+  input|type: enter (followed by the text to enter in monospace) # https://redhat-documentation.github.io/supplementary-style-guide/#text-entry
   recommend: direct users to take the recommended action
   refer to: see
   roll-out|roll out|rollout: roll out (verb)|rollout (noun)


### PR DESCRIPTION

implements https://redhat-documentation.github.io/supplementary-style-guide/#text-entry
fixes #129 