### PR TITLE
CONTRIBUTING.adoc: update outdated URL

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,6 +1,6 @@
 # Contributor's guide
 
-* See: link:https://redhat-documentation/vale-at-red-hat/docs/end-user-guide/contributing/[Contributing].
+* See: link:https://redhat-documentation.github.io/vale-at-red-hat/docs/contributor-guide/contributing/[Contributing].
 
 ## Certificate of origin
 


### PR DESCRIPTION
The URL in the repo's `CONTRIBUTING.adoc` was broken. This PR updates it to the current URL.