### PR TITLE
chore: allow using latest vale action

### DIFF
--- a/.github/workflows/vale-on-pull.yml
+++ b/.github/workflows/vale-on-pull.yml
@@ -18,8 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Vale Linter
-        uses: errata-ai/vale-action@v1.4.0
+        uses: errata-ai/vale-action@v1
         with:
           files: __onlyModified
+          onlyAnnotateModifiedLines: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/vale-on-push.yml
+++ b/.github/workflows/vale-on-push.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Vale Linter
-        uses: errata-ai/vale-action@v1.4.0
+        uses: errata-ai/vale-action@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/modules/user-guide/pages/using-vale-github-action.adoc
+++ b/modules/user-guide/pages/using-vale-github-action.adoc
@@ -31,8 +31,7 @@ WARNING: Due to the GitHub token permissions, this Action can not post annotatio
 ----
 name: Linting with Vale
 on:
-  - pull_request
-  - push
+  - pull_request_target
 jobs:
   prose:
     runs-on: ubuntu-latest
@@ -41,9 +40,10 @@ jobs:
         uses: actions/checkout@master
 
       - name: Vale Linter
-        uses: errata-ai/vale-action@v1.4.0
+        uses: errata-ai/vale-action@v1
         with:
           files: __onlyModified
+          onlyAnnotateModifiedLines: true
           styles: https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip
           config: https://raw.githubusercontent.com/redhat-documentation/vale-at-red-hat/master/.vale-for-github-action.ini
         env:


### PR DESCRIPTION
* chore: https://github.com/errata-ai/vale-action  1.5.0 is out, let the worklows automatically pick the latest 1.x version
* chore: add onlyAnnotateModifiedLines: true