### PR TITLE
Updating reference files to be excluded from vale linting

### DIFF
--- a/modules/reference-guide/partials/ref_error_terms.adoc
+++ b/modules/reference-guide/partials/ref_error_terms.adoc
@@ -6,7 +6,6 @@ The following table lists incorrect terminology and the approved usage as outlin
 
 pass:[<!-- vale RedHat.CaseSensitiveTerms = NO -->]
 pass:[<!-- vale RedHat.TermsErrors = NO -->]
-pass:[<!-- vale RedHat.Spelling = NO -->]
 
 .Supplementary Style Guide terminology guidance
 [options="header"]
@@ -21,7 +20,9 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 
 |bottle neck \| bottle-neck|link:https://redhat-documentation.github.io/supplementary-style-guide/#bottleneck[bottleneck]
 
-|broad cast \| broad-cast|link:https://redhat-documentation.github.io/supplementary-style-guide/#broadcast-v[broadcast]
+|broad cast \| broad-cast (as a noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#broadcast-n[broadcast]
+
+|broad cast \| broad-cast (as a verb)|link:https://redhat-documentation.github.io/supplementary-style-guide/#broadcast-v[broadcast]
 
 |air wall|link:https://redhat-documentation.github.io/supplementary-style-guide/#air-gap[air gap]
 
@@ -71,7 +72,9 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 
 |crossplatform \| cross platform|link:https://redhat-documentation.github.io/supplementary-style-guide/#cross-platform[cross-platform]
 
-|daisy-chain \| daisychain|link:https://redhat-documentation.github.io/supplementary-style-guide/#daisy-chain-n[daisy chain]
+|daisy-chain \| daisychain (as a noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#daisy-chain-n[daisy chain]
+
+|daisy-chain \| daisychain (as a verb)|link:https://redhat-documentation.github.io/supplementary-style-guide/#daisy-chain-v[daisy chain]
 
 |datacenter \| data-center \| data centre \| datacentre|link:https://redhat-documentation.github.io/supplementary-style-guide/#data-center[data center]
 
@@ -79,11 +82,15 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 
 |datapath|link:https://redhat-documentation.github.io/supplementary-style-guide/#data-path-n[data path]
 
-|de-bug|link:https://redhat-documentation.github.io/supplementary-style-guide/#debug-adj[debug]
+|de-bug (as a adjective)|link:https://redhat-documentation.github.io/supplementary-style-guide/#debug-adj[debug]
+
+|de-bug (as a verb)|link:https://redhat-documentation.github.io/supplementary-style-guide/#debug-v[debug]
 
 |desire \| wish|link:https://redhat-documentation.github.io/supplementary-style-guide/#need[need]
 
-|desk top \| desk-top|link:https://redhat-documentation.github.io/supplementary-style-guide/#desktop-adj[desktop]
+|desk top \| desk-top (as an adjective)|link:https://redhat-documentation.github.io/supplementary-style-guide/#desktop-adj[desktop]
+
+|desk top \| desk-top (as an noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#desktop-n[desktop]
 
 |different than \| different to|link:https://redhat-documentation.github.io/supplementary-style-guide/#different[different from]
 
@@ -91,9 +98,13 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 
 |domainname \| domain-name|link:https://redhat-documentation.github.io/supplementary-style-guide/#domain-name[domain name]
 
-|down-load \| down load|link:https://redhat-documentation.github.io/supplementary-style-guide/#download-n[download]
+|down-load \| down load (as a noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#download-n[download]
 
-|down-stream \| down stream|link:https://redhat-documentation.github.io/supplementary-style-guide/#downstream-adj[downstream]
+|down-load \| down load (as a verb)|link:https://redhat-documentation.github.io/supplementary-style-guide/#download-v[download]
+
+|down-stream \| down stream  (as an adjective)|link:https://redhat-documentation.github.io/supplementary-style-guide/#downstream-adj[downstream]
+
+|down-stream \| down stream  (as a noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#downstream-n[downstream]
 
 |dualboot \| dual boot|link:https://redhat-documentation.github.io/supplementary-style-guide/#dual-boot[dual-boot]
 
@@ -223,7 +234,7 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 
 |the installer|link:https://redhat-documentation.github.io/supplementary-style-guide/#installation-program[installation program]
 
-|thin-provisioned \| thinly provisioned \| thinly-provisioned|link:https://redhat-documentation.github.io/supplementary-style-guide/#thin-provisioned[thin-provisioned]
+|thinly provisioned \| thinly-provisioned|link:https://redhat-documentation.github.io/supplementary-style-guide/#thin-provisioned[thin-provisioned]
 
 |tier-one \| tier 1|link:https://redhat-documentation.github.io/supplementary-style-guide/#tier-1[tier-1]
 
@@ -235,9 +246,9 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 
 |up-selling \| up selling|link:https://redhat-documentation.github.io/supplementary-style-guide/#upselling[upselling]
 
-|up-stream \| up stream|link:https://redhat-documentation.github.io/supplementary-style-guide/#upstream-n[upstream]
+|up-stream \| up stream (as a noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#upstream-n[upstream]
 
-|up-stream \| up stream|link:https://redhat-documentation.github.io/supplementary-style-guide/#upstream-adj[upstream]
+|up-stream \| up stream (as a adjective)|link:https://redhat-documentation.github.io/supplementary-style-guide/#upstream-adj[upstream]
 
 |up-time \| up time|link:https://redhat-documentation.github.io/supplementary-style-guide/#uptime[uptime]
 
@@ -246,6 +257,5 @@ pass:[<!-- vale RedHat.Spelling = NO -->]
 |video-mode \| videomode|link:https://redhat-documentation.github.io/supplementary-style-guide/#video-mode[video mode]
 
 |wish \| would like|link:https://redhat-documentation.github.io/supplementary-style-guide/#want[want]
-
 |====
 

--- a/modules/reference-guide/partials/ref_suggestion_terms.adoc
+++ b/modules/reference-guide/partials/ref_suggestion_terms.adoc
@@ -4,6 +4,8 @@
 
 The following table lists incorrect terminology and the approved usage as outlined in the Red Hat Supplementary Style Guide.
 
+pass:[<!-- vale RedHat.CaseSensitiveTerms = NO -->]
+pass:[<!-- vale RedHat.TermsSuggestions = NO -->]
 pass:[<!-- vale RedHat.TermsErrors = NO -->]
 
 .Supplementary Style Guide terminology guidance
@@ -11,16 +13,18 @@ pass:[<!-- vale RedHat.TermsErrors = NO -->]
 |====
 |Incorrect term|Correct term
 
-|command prompt OR terminal OR shell|link:https://redhat-documentation.github.io/supplementary-style-guide/#shell-prompt[shell prompt]
+|command prompt \| terminal \| shell|link:https://redhat-documentation.github.io/supplementary-style-guide/#shell-prompt[shell prompt]
 
 |channel|link:https://redhat-documentation.github.io/supplementary-style-guide/#repository[repository]
 
-|Cloud|link:https://redhat-documentation.github.io/supplementary-style-guide/#cloud-adj[cloud]
+|cloud (as an adjective)|link:https://redhat-documentation.github.io/supplementary-style-guide/#cloud-adj[cloud]
+
+|Cloud (as a noun)|link:https://redhat-documentation.github.io/supplementary-style-guide/#cloud-n[cloud]
 
 |code|link:https://redhat-documentation.github.io/supplementary-style-guide/#write[write]
 
 |refer to|link:https://redhat-documentation.github.io/supplementary-style-guide/#see[see]
 
-|segfault (verb)|link:https://redhat-documentation.github.io/supplementary-style-guide/#segmentation-fault[segmentation fault]
+|segfault as a verb|link:https://redhat-documentation.github.io/supplementary-style-guide/#segmentation-fault[segmentation fault]
 |====
 

--- a/modules/reference-guide/partials/ref_warning_terms.adoc
+++ b/modules/reference-guide/partials/ref_warning_terms.adoc
@@ -4,7 +4,9 @@
 
 The following table lists incorrect terminology and the approved usage.
 
+pass:[<!-- vale RedHat.CaseSensitiveTerms = NO -->]
 pass:[<!-- vale RedHat.TermsWarnings = NO -->]
+pass:[<!-- vale RedHat.TermsErrors = NO -->]
 
 .Warning terms guidance
 [options="header"]

--- a/tools/create-ssg-refs.py
+++ b/tools/create-ssg-refs.py
@@ -124,8 +124,8 @@ def get_ssg_terms(temp_dir):
                     #clean regex special characters hack - this needs to be handled correctly
                     incorrect_forms = re.sub(r'\/', ' ', incorrect_forms)
                     incorrect_forms = re.sub(r'\^', '', incorrect_forms)
-                    incorrect_forms = re.sub(r'\(', '\(', incorrect_forms)
-                    incorrect_forms = re.sub(r'\)', '\)', incorrect_forms)
+                    incorrect_forms = re.sub(r'\(', '\\(', incorrect_forms)
+                    incorrect_forms = re.sub(r'\)', '\\)', incorrect_forms)
                     #write the terms into the dict
                     ssg_term_dict["ssg_term"]["word_id"] = word_id
                     ssg_term_dict["ssg_term"]["correct_term"] = correct_form
@@ -168,6 +168,13 @@ def write_ref_tables(temp_dir, adoc_dir, error_type):
         w.write("\n")
         w.write("The following table lists incorrect terminology and the approved usage as outlined in the Red Hat Supplementary Style Guide." + "\n")
         w.write("\n")
+        #Add scope escaping for generated terms
+        w.write("pass:[<!-- vale RedHat.CaseSensitiveTerms = NO -->]" + "\n")
+        w.write("pass:[<!-- vale RedHat.TermsErrors = NO -->]" + "\n")
+        w.write("pass:[<!-- vale RedHat.TermsSuggestions = NO -->]" + "\n")
+        w.write("pass:[<!-- vale RedHat.TermsWarnings = NO -->]" + "\n")
+        w.write("pass:[<!-- vale RedHat.Spelling = NO -->]" + "\n")
+        w.write("\n")
         w.write(".Supplementary Style Guide terminology guidance" + "\n")
         w.write("[options=\"header\"]" + "\n")
         w.write("|====" + "\n")
@@ -184,8 +191,8 @@ def write_ref_tables(temp_dir, adoc_dir, error_type):
                         correct = line["ssg_term"]["correct_term"]
                         incorrect = line["ssg_term"]["incorrect_forms"]
                         #re.sub pipe char
-                        incorrect = re.sub(r'\|', ' OR ', incorrect)
-                        correct = re.sub(r'\|', ' OR ', correct)
+                        incorrect = re.sub(r'\|', ' \\| ', incorrect)
+                        correct = re.sub(r'\|', ' \\| ', correct)
                         w.write("\n")
                         w.write("|" + incorrect + "|" + "link:https://redhat-documentation.github.io/supplementary-style-guide/#" + word_id + "[" + correct + "]" + "\n")
         #close it out


### PR DESCRIPTION
Adding vale.ini to ignore reference files from the vale linting since they list every error word. This effort is to reduce the spurious Vale linting errors.