### PR TITLE
Installing Vale from release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Create release
         run: |
           cd .vale/styles
+          echo $GITHUB_RUN_NUMBER > version.txt
           zip -r RedHat.zip RedHat
           gh release create v$GITHUB_RUN_NUMBER 'RedHat.zip'
         env:

--- a/modules/user-guide/nav.adoc
+++ b/modules/user-guide/nav.adoc
@@ -2,6 +2,7 @@
 
 * xref:introduction.adoc[]
 * xref:installing-vale-cli.adoc[]
+* xref:installing-vale-from-zip.adoc[]
 * xref:using-vale-in-the-ide.adoc[]
 * xref:redhat-style-for-vale.adoc[]
 * xref:glossary.adoc[]

--- a/modules/user-guide/pages/installing-vale-cli.adoc
+++ b/modules/user-guide/pages/installing-vale-cli.adoc
@@ -1,5 +1,5 @@
 // Metadata for Antora
-:navtitle: Installing Vale CLI
+:navtitle: Installing Vale by cloning the *{repository-name}* repo
 :keywords: vale
 :page-aliases: end-user-guide:using-vale-cli.adoc
 :description: Describes how to install and configure the Vale CLI
@@ -8,9 +8,11 @@
 :context: assembly_getting-started-with-vale
 :_module-type: PROCEDURE
 [id="proc_using-vale-cli-on-a-local-environment_{context}"]
-= Installing and configuring Vale
+= Installing and configuring Vale by cloning the *{repository-name}* repo
 
-To use `vale` CLI on any project in your local environment without further configuration in the projects, install the `vale` CLI and register the *{repository-name}* Vale configuration as the default.
+To use `vale` CLI on any project in your local environment, install the `vale` CLI and register the *{repository-name}* Vale configuration as the default.
+
+NOTE: Alternatively, if you do not intend to contribute to the *{repository-name}* project, you can configure the `RedHat` Vale style by downloading the latest release from GitHub. See xref:installing-vale-from-zip.adoc[]
 
 .Prerequisites
 
@@ -22,7 +24,7 @@ To use `vale` CLI on any project in your local environment without further confi
 +
 NOTE: On the Vale site, click the tab for your operating system.
 
-. Get a copy of the link:{repository-url}[{repository-name} repository] to your local environment.
+. Clone the link:{repository-url}[{repository-name} repository] in your local environment.
 +
 [subs="+quotes,+attributes"]
 ----

--- a/modules/user-guide/pages/installing-vale-from-zip.adoc
+++ b/modules/user-guide/pages/installing-vale-from-zip.adoc
@@ -1,0 +1,47 @@
+// Metadata for Antora
+:navtitle: Installing Vale from the latest release
+:keywords: vale
+:description: Describes how to install from the latest release and configure the Vale CLI
+// End of metadata for Antora
+
+:context: assembly_getting-started-with-vale
+:_module-type: PROCEDURE
+[id="proc_using-vale-cli-on-a-local-environment-zip_{context}"]
+= Installing and configuring Vale from the latest release
+
+To use `vale` CLI on any project in your local environment without further configuration in the projects, install the `vale` CLI and configure the `RedHat` style by downloading the latest release from GitHub.
+
+Use this procedure if you want to use the `RedHat` style and you do not intend to contribute to the project.
+
+.Procedure
+
+. Install the Vale command-line tool on your workstation. See link:https://docs.errata.ai/vale/install[Installing Vale].
++
+NOTE: On the Vale site, click the tab for your operating system.
+
+. Run the following command to download the latest `RedHat` Vale rules and register the Vale configuration as the default.
++
+[subs="+quotes,+attributes"]
+----
+$ curl https://raw.githubusercontent.com/redhat-documentation/vale-at-red-hat/tools/get-vale-styles-release.sh | bash -s
+----
+
+.Verification
+
+. Run the `vale` command on one of your content files.
++
+[subs="+quotes,+attributes"]
+----
+$ cd __<project_directory>__
+$ vale __<filename>__
+----
+
+. Review the vale output and use it to update your content file.
+
+. Re-run the same `vale` command to see the updated results.
+
+.Additional resources
+
+* xref:understanding-vale-output.adoc[]
+* xref:defining-a-vale-onboarding-strategy.adoc[]
+

--- a/tools/get-vale-styles-release.sh
+++ b/tools/get-vale-styles-release.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Fail on errors
+set -e
+
+umask 002
+
+# Get fresh Vale styles from GitHub release zip
+cd "$HOME"
+wget -q --timestamping -O ".vale.ini" https://raw.githubusercontent.com/redhat-documentation/vale-at-red-hat/main/.vale.ini
+mkdir -p .vale/styles
+cd .vale/styles || exit
+rm -rf RedHat 
+wget -q --timestamping https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip
+unzip -q RedHat.zip
+rm RedHat.zip
+echo "vale-at-red-hat style installed to .vale/styles. Go lint!"


### PR DESCRIPTION
This PR: 

* Adds version.txt to release zip
* Adds new procedure: how to install from release zip
* Adds new install from release zip script

partially addresses https://github.com/redhat-documentation/vale-at-red-hat/issues/211