### PR TITLE
Fix issue #209: Do not flag valid uses of "machine"

### DIFF
--- a/.vale/fixtures/RedHat/Usage/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Usage/testvalid.adoc
@@ -1,1 +1,3 @@
 pop-up
+virtual machine
+machine learning

--- a/.vale/styles/RedHat/Usage.yml
+++ b/.vale/styles/RedHat/Usage.yml
@@ -96,7 +96,7 @@ tokens:
   - localize
   - look and feel
   - look-and-feel
-  - machine
+  - "(?<!virtual )machine(?! learning)"
   - master and slave
   - migrate
   - native


### PR DESCRIPTION
As per the style guide, both "virtual machine" and "machine learning" are permitted. This fix ensures that these valid uses of the word "machine", including variations such as "Java Virtual Machine", are no longer flagged.