### PR TITLE
Do not flag "backtrace" and "traceback"

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -12,6 +12,8 @@ AWS
 Azure
 backfilling
 Backfilling
+backtrace
+Backtrace
 Bierner
 bindable
 Bindable
@@ -259,6 +261,8 @@ Texinfo
 Theia
 Tolerations
 Toolset
+traceback
+Traceback
 Traefik
 Truststore
 Uber

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -12,6 +12,7 @@ filters:
   - 'Node\.js'
   - "[aA]utostart"
   - "[bB]ackfilling"
+  - "[bB]acktrace"
   - "[bB]indable"
   - "[bB]oolean"
   - "[bB]reakpoint"
@@ -110,6 +111,7 @@ filters:
   - "[sS]ystemd"
   - "[tT]heia"
   - "[tT]olerations"
+  - "[tT]raceback"
   - "[tT]ruststore"
   - "[uU]ncomment"
   - "[uU]ndercloud"


### PR DESCRIPTION
Both "backtrace" and "traceback" are valid terms in computing and used frequently when documenting debugging procedures. They are not listed flagged as incorrect in any of our style guides so I do not see a reason why they should be flagged by Vale as incorrect.