### PR TITLE
Do not flag "such as"

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
@@ -9,6 +9,7 @@ segmentation fault
 shell prompt
 shell script
 Start by using this.
+such as
 write
 this clause that is restrictive
 this clause, which is nonrestrictive

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -12,8 +12,8 @@ swap:
   "shell(?! prompt| script)": shell prompt
   ", that": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
   "(?<!,) which": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
+  "(?<!such )as": because|while
   and so on: "appropriate descriptive wording, unless you list a clear sequence of elements"
-  as: because|while
   bare metal|bare-metal: bare metal (noun)|bare-metal (adjective)
   Bps|bps: Bps (bytes per second)|bps (bits per second)
   client side|client-side: client-side (adjective)| client side (noun)


### PR DESCRIPTION
While the style guide does not explicitly states its opinion on using "such as" in product documentation, it uses it excessively throughout the Word usage section. As it is a common phrase, not ignoring it caused the term suggestion for "as" to generate too many misguided suggestions.