### PR TITLE
Do not flag /var when used as an obvious path

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -1,3 +1,4 @@
+/var
 BIND
 bind 
 BIOS

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -114,7 +114,7 @@ swap:
   ULTRASPARC|UltraSparc: UltraSPARC
   Unix|unix|UNIX-like: UNIX
   url: URL
-  var: VAR
+  "(?<!/)var": VAR
   VI: vi
   VIM|vim: Vim
   Virtual Desktop Server Management: VDSM


### PR DESCRIPTION
The supplementary style guide defines VAR as an acronym for "value-added reseller" but unfortunately the existing definition also incorrectly reports all occurrences of "/var" when used as a system directory. This fix ensures that obvious directories are skipped.