### PR TITLE
Do not suggest 'discuss' for 'address' used as a noun

### DIFF
--- a/.vale/fixtures/RedHat/SimpleWords/testvalid.adoc
+++ b/.vale/fixtures/RedHat/SimpleWords/testvalid.adoc
@@ -4,6 +4,7 @@ agree
 aim
 allow
 allowed
+an address
 ask
 assign
 award
@@ -56,6 +57,9 @@ improve
 include
 included
 inside
+IP address
+IPv4 address
+IPv6 address
 keep
 large
 late
@@ -64,6 +68,7 @@ latest
 leave
 let
 listed
+MAC address
 many
 meet
 merge
@@ -103,6 +108,7 @@ stop
 stress
 support
 tell
+the address
 total
 try
 use

--- a/.vale/styles/RedHat/SimpleWords.yml
+++ b/.vale/styles/RedHat/SimpleWords.yml
@@ -20,7 +20,7 @@ swap:
   accurate: right|exact
   acquiesce: agree
   acquire: get|buy
-  address: discuss
+  "(?<!an |the |IP |IPv[46] |MAC )address": discuss
   addressees: you
   adjacent to: next to
   adjustment: change


### PR DESCRIPTION
While it is difficult to reliably recognize a noun when defining vale rules, I run a quick search on Red Hat documentatiton and it looks like a few combinations are incredibely far more common than others. Consequently, I adapted the definition to avoid flagging these word combinations.