### PR TITLE
Do not report recommended terms in Slash

### DIFF
--- a/.vale/fixtures/RedHat/Slash/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Slash/testvalid.adoc
@@ -3,3 +3,7 @@ upstream/downstream
 I/O
 z/OS
 z/OSMF
+client/server
+input/output
+Input/Output
+N/A

--- a/.vale/styles/RedHat/Slash.yml
+++ b/.vale/styles/RedHat/Slash.yml
@@ -8,7 +8,10 @@ source: "IBM - Slashes, p. 68"
 tokens:
   - '\w+/\w+'
 exceptions:
+  - "client/server"
   - "I/O"
+  - "[Ii]nput/[Oo]utput"
+  - "N/A"
   - "SSL/TLS"
   - "upstream/downstream"
   - "z/OS"


### PR DESCRIPTION
The IBM Style Guide explicitly allows N/A in situations where spelling
it out is impractical. It also explicitly recommends the use or
client/server and input/output with the slash so I added all of these to
the exceptions.

I realize that this style has ignorecase enabled but for some reason,
with vale 2.18.0, it still flagged Input/Output which is a very common
way of writing it in documentation. That is why I went ahead and used a
pattern match.