### PR TITLE
Avoid false positives for IP address ranges that begin with "0/"

### DIFF
--- a/.vale/styles/RedHat/Slash.yml
+++ b/.vale/styles/RedHat/Slash.yml
@@ -16,3 +16,4 @@ exceptions:
   - "upstream/downstream"
   - "z/OS"
   - "z/OSMF"
+  - "0/"


### PR DESCRIPTION
The following warnings are false positives for IP address ranges in phrases like this:
```
an libvirt. For libvirt, the default is `192.168.126.0/24`.
|Optional. The IP address pools for services. The default is 172.30.0.0/16.
NOTE: IP networks are represented as strings using Classless Inter-Domain Routing (CIDR) notation with a traditional IP address or network number, followed by the "/" (slash) character, followed by a decimal value between 0 and 32 that describes the number of significant bits. For example, 10.0.0.0/16 represents IP addresses 10.0.0.0 through 10.0.255.255.
```
, which produce warnings like this:
```
238:13   warning  Use either 'or' or 'and' in     RedHat.Slash              
                   '0/14'                                                    
 252:2    warning  Use correct American English    RedHat.Spelling           
                   spelling. Did you really mean                             
                   'adresses'?                                               
 268:71   warning  Use either 'or' or 'and' in     RedHat.Slash              
                   '0/16'                                                    
 287:299  warning  Use either 'or' or 'and' in     RedHat.Slash              
                   '0/16'   
```