### PR TITLE
Add asciidoctor as prerequisite to use vale with Red Hat styles

### DIFF
--- a/modules/user-guide/pages/installing-vale-cli.adoc
+++ b/modules/user-guide/pages/installing-vale-cli.adoc
@@ -17,6 +17,7 @@ NOTE: Alternatively, if you do not intend to contribute to the *{repository-name
 .Prerequisites
 
 * The `git` tool is installed.
+* The `asciidoctor` tool is installed. See link:https://docs.asciidoctor.org/asciidoctor/latest/install/[Installing AsciiDoctor]
 
 .Procedure
 


### PR DESCRIPTION
If not installed, there is this error:

```
E100 [lintAdoc] Runtime error

asciidoctor not found

Execution stopped with code 1.
```