### PR TITLE
Add Navigate to Vale suggestion words

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -32,3 +32,5 @@ user space
 user-space
 userspace
 zip
+Navigate
+navigate

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -32,3 +32,4 @@ swap:
   thru|through: "' - ' (range)|by using|finished|completed"
   user space|userspace|user-space: user space (noun)| user-space (modifier)
   zip: compress
+  Navigate|navigate: '"click", "select", "browse", or "go to"'


### PR DESCRIPTION
IN the IBMSG, [navigate](https://www.ibm.com/docs/en/ibm-style?topic=word-usage) is a use with caution term. This PR adds navigate to the suggestions rule.

```
Use with caution navigate (verb)
Use only when a more direct verb, such as "click", "select", "browse", or "go to", is not applicable. Use only to provide direction to a location (for example, "Navigate to the directory that contains the files that you want to edit").
```