### PR TITLE
Report the invalid use of 'demon' instead of 'daemon'

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -107,6 +107,7 @@ deinstall
 deinstallation
 demilitarized zone
 demo
+demon
 depress
 deregister
 desire

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -66,6 +66,7 @@ create
 create retrieve update and delete
 cross-platform
 cross-site scripting
+daemon
 daisy chain
 data
 data center

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -102,6 +102,7 @@ swap:
   deinstallation: uninstallation
   demilitarized zone: DMZ
   demo: demonstration
+  demon: daemon
   depress: press|type
   deregister: unregister
   desire: want|required


### PR DESCRIPTION
The IBM Style Guide prohibits the use of the word 'demon' to describe a program running in the background. This is a common typo in documentation though so Vale should warn about it.