### PR TITLE
Do not flag "SELinux" as invalid spelling

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -230,6 +230,7 @@ Runtimes
 Sakila
 SCM
 Scrollbar
+SELinux
 Semeru
 Serializer
 Serverless

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -252,6 +252,7 @@ filters:
   - Rolfe
   - Sakila
   - SCM
+  - SELinux
   - Semeru
   - Shadowman
   - startx


### PR DESCRIPTION
The  `Spelling.yml` rules incorreclty issue a warning to use correct American English spelling for "SELinux". This fix prevents that.

There already are rules for correct spelling of SELinux in `CaseSensitiveTerms.yml` and `Headings.yml`.