### PR TITLE
Fixes ConfigMap reporting words ending in "config"

### DIFF
--- a/.vale/fixtures/RedHat/ConfigMap/testvalid.adoc
+++ b/.vale/fixtures/RedHat/ConfigMap/testvalid.adoc
@@ -1,3 +1,5 @@
 valid content: config map
 valid content: config maps
 valid content: configure
+valid content: kubeconfig
+

--- a/.vale/styles/RedHat/ConfigMap.yml
+++ b/.vale/styles/RedHat/ConfigMap.yml
@@ -5,4 +5,4 @@ level: error
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/configmap/
 message: "Do not use 'config', unless it is followed by 'map'."
 raw:
-    - 'config([[:punct:]]|$|\s(?!maps?\b))'
+    - '\bconfig([[:punct:]]|$|\s(?!maps?\b))'


### PR DESCRIPTION
Closes #260

Adds a word boundary (\b) before "config" so that the ConfigMap
rule will not report as errors words or terms that end in
"config", for example, "kubeconfig".