### PR TITLE
fix: Do not flag "productized" or "productize" as invalid spelling

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -200,6 +200,8 @@ PostgreSQL
 preconfigured
 Preconfigured
 prepended
+productize
+productized
 Prometheus
 Pulldown
 Pytorch

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -127,6 +127,8 @@ exceptions:
   - PostgreSQL
   - PostScript
   - PowerPC
+  - Productize
+  - Productized
   - Prometheus
   - Pytorch
   - qeth

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -67,6 +67,8 @@ filters:
   - "[oO]perator"
   - "[pP]reconfigured"
   - "[pP]ulldown"
+  - "[pP]roductize"
+  - "[pP]roductized"
   - "[rR]eadonly"
   - "[rR]ebalance"
   - "[rR]ebalances"


### PR DESCRIPTION
The _**Spelling.yml**_ rules incorrectly warn that "productized" and "productize" are unknown words. 

This PR prevents a false-positive spelling suggestion for the words  "productized" and "productize". 

Note: These words are in the Oxford, Cambridge, Macmillian, and several other international dictionaries.

![image](https://user-images.githubusercontent.com/92924207/187176491-d6bdf11c-fd2a-457d-a824-74db1391c62a.png)
