### PR TITLE
fix: Make vale.ini config sample match install doc

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,9 +6,8 @@
 # The relative path to the folder containing linting rules (styles).
 StylesPath = .vale/styles
 
-# Vocab define the exceptions to use in *all* `BasedOnStyles`.
-# See: https://docs.errata.ai/vale/vocab
-; Vocab = RedHat
+# Optional: Use the `Vocab` parameter to define exceptions to the ruleset specified for `BasedOnStyles`.
+# For more information about how to use the `Vocab` feature of vale, see: https://docs.errata.ai/vale/vocab
 
 # Minimum alert level
 # -------------------

--- a/modules/user-guide/pages/installing-vale-cli.adoc
+++ b/modules/user-guide/pages/installing-vale-cli.adoc
@@ -29,7 +29,6 @@ On the Vale site, click the tab for your operating system.
 StylesPath = styles
 
 MinAlertLevel = suggestion
-Vocab = Base
 
 Packages = RedHat
 


### PR DESCRIPTION
The sample `.vale.ini `that is provided in the [Red Hat package and repo does](https://github.com/redhat-documentation/vale-at-red-hat/blob/main/.vale.ini) not mirror the recommended configuration of the following topic:

[Installing Vale with the RedHat package](https://redhat-documentation.github.io/vale-at-red-hat/docs/user-guide/installing-vale-cli/)





![image](https://user-images.githubusercontent.com/92924207/187218053-bcbcc4bb-52c6-4c98-9105-f12f7322f65a.png)
