### PR TITLE
feat: Add SmallRye to spelling and heading rules

### DIFF
--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -1,3 +1,4 @@
 = A valid heading
 == GitLab Code Quality
 == The Infinispan project
+== Installing SmallRye to do xyz

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -48,6 +48,7 @@ podman
 quarkus
 restic
 scm
+Smallrye
 svg
 uber
 uri

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -239,6 +239,7 @@ Serializer
 Serverless
 Shadowman
 Sharding
+SmallRye
 startx
 su
 Subcommand

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -97,6 +97,7 @@ swap:
   Shadow Man|ShadowMan: Shadowman
   Shadow passwords: shadow passwords
   Shadow utilities: shadow utilities
+  Smallrye: SmallRye
   socks: SOCKS
   software collection|Software collection: Software Collection
   Spring boot: Spring Boot

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -141,6 +141,7 @@ exceptions:
   - SCM
   - SELinux
   - Semeru
+  - SmallRye
   - Shadowman
   - StarOffice
   - startx

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -258,6 +258,7 @@ filters:
   - SELinux
   - Semeru
   - Shadowman
+  - SmallRye
   - startx
   - Suchow
   - SVG


### PR DESCRIPTION
The Spelling.yml and Heading.yml rules incorrectly detect spelling and capitalization issues with the open-source community project SmallRye.

**SmallRye** is a project to share and collaborate on implementing specifications that are part of Eclipse MicroProfile. SmallRye is used in many Red Hat products, including products in the Runtimes portfolio.