### PR TITLE
feat: Add RESTEasy to spelling & capitalization

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -145,6 +145,9 @@ Red Boot
 Red Hat Proxy
 Red Hat Satellite
 Redboot
+resteasy
+Resteasy
+RESTEASY
 rom
 Rom
 rpm

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -85,6 +85,7 @@ raw
 Red Hat Network Proxy Server
 Red Hat Network Satellite Server
 RedBoot
+RESTEasy
 ROM
 RPM
 S-record

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -2,3 +2,4 @@
 == GitLab Code Quality
 == The Infinispan project
 == Installing SmallRye to do xyz
+== Installing RESTEasy with Quarkus

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -48,7 +48,6 @@ podman
 quarkus
 restic
 scm
-Smallrye
 svg
 uber
 uri

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -223,6 +223,7 @@ Redistributions
 Reshard
 Resharding
 Reshards
+RESTEasy
 Restic
 Resyncing
 Rolfe

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -88,6 +88,7 @@ swap:
   Red Hat Proxy: Red Hat Network Proxy Server
   Red Hat Satellite: Red Hat Network Satellite Server
   Redboot|Red Boot: RedBoot
+  RESTEASY|resteasy|Resteasy: RESTEasy
   Rom|rom: ROM
   rpm: RPM
   s-record|S-Record|s-Record|SREC: S-record

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -136,6 +136,7 @@ exceptions:
   - Red Hat
   - RedBoot
   - Redistributions
+  - RESTEasy
   - Rolfe
   - Sakila
   - SCM

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -255,6 +255,7 @@ filters:
   - Quarkus
   - Redistributions
   - Restic
+  - RESTEasy
   - Rolfe
   - Sakila
   - SCM


### PR DESCRIPTION
The Spelling.yml and Heading.yml rules incorrectly detect spelling and capitalization issues with the open-source community project **RESTEasy**.

**RESTEasy** is a JBoss / Red Hat project that provides various frameworks to help you build RESTful Web Services and RESTful Java applications. **RESTEasy** is used in many Red Hat products, including products in the Runtimes portfolio. This PR prevents spelling and capitalization suggestion churn in the vale output.