### PR TITLE
Match only if YAML is used as a word

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -220,3 +220,5 @@ WindowMaker
 Xemacs
 Xterm
 yaml
+Yaml is not a markup language.
+Compared to yaml, JSON has way more curly braces.

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -1,6 +1,6 @@
 /var
 BIND
-bind 
+bind
 BIOS
 Btrfs
 CapEx
@@ -126,3 +126,4 @@ Window Maker
 XEmacs
 xterm
 YAML
+File extension example.yaml must pass.

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -131,4 +131,4 @@ swap:
   Window-Maker|WindowMaker: Window Maker
   Xemacs: XEmacs
   Xterm: xterm
-  yaml: YAML
+  '\s([Yy]aml)|^([Yy]aml)': YAML

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -131,4 +131,4 @@ swap:
   Window-Maker|WindowMaker: Window Maker
   Xemacs: XEmacs
   Xterm: xterm
-  '\s([Yy]aml)|^([Yy]aml)': YAML
+  '\s(?:[Yy]aml)|^(?:[Yy]aml)': YAML


### PR DESCRIPTION
Currently shows error `RedHat.CaseSensitiveTerms	Use 'YAML' rather than 'yaml'.` for the line 

.Example plugin.yaml

This check ensures that the check will only match `Yaml` and `yaml` when used as words.