### PR TITLE
Spelling rules updates: Add 'allowlist' to spelling ignore list

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -1,5 +1,7 @@
 a .NET application
 adoc
+Allowlist
+allowlist
 Annobin
 Ansible
 Antora

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -10,6 +10,7 @@ filters:
   - '\.NET'
   - 'I/O'
   - 'Node\.js'
+  - "[aA]llowlist"
   - "[aA]utostart"
   - "[bB]ackfilling"
   - "[bB]acktrace"


### PR DESCRIPTION
Allowlist is a valid term: https://redhat-documentation.github.io/supplementary-style-guide/#user-interface-elements

It should not be caught in the spelling filter. This PR fixes this issue.