### PR TITLE
feat: add SLAs in the Spelling rule

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -241,6 +241,8 @@ Serializer
 Serverless
 Shadowman
 Sharding
+SLA
+SLAs
 startx
 su
 Subcommand

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -258,6 +258,7 @@ filters:
   - SCM
   - SELinux
   - Semeru
+  - SLAs
   - Shadowman
   - startx
   - Suchow


### PR DESCRIPTION
Example usage:

> Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. 