### PR TITLE
feat: add proxied to the Spelling rule

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -206,6 +206,7 @@ prepended
 productize
 productized
 Prometheus
+proxied
 Pulldown
 Pytorch
 qeth

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -249,6 +249,7 @@ filters:
   - preconfigured
   - prepended
   - Prometheus
+  - proxied
   - Pytorch
   - qeth
   - Quarkus


### PR DESCRIPTION
past tense of [proxy](https://www.merriam-webster.com/dictionary/proxy)

https://www.merriam-webster.com/dictionary/proxied

Example usage: 

> In workspaces that use the default Che-Theia IDE in a proxied environment, the *Workspace* panel might appear blank rather than showing available commands, terminals, and applications.