### PR TITLE
Add common Java programming words to spelling & heading exceptions

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -54,6 +54,8 @@ gnu
 Gnu
 gpl
 Gpl
+Graalvm
+graalVM
 Grub
 gtk
 Gtk
@@ -76,6 +78,8 @@ iso
 iso image
 Itanium2
 JBoss.org
+Junit
+junit
 jvm
 Jvm
 kernel-based virtual machine
@@ -85,7 +89,12 @@ lan
 Lan
 linux
 LINUX
+Microprofile
+micro-profile
 MicroSoft
+mongoDB
+Mongodb
+Mongo-db
 MS
 ms-dos
 Ms-Dos
@@ -93,6 +102,9 @@ MS-dos
 msdos
 MSDOS
 MSFT
+mutual tls
+Mutual tls
+Mutual TLS
 mySQL
 MYSQL
 node.js
@@ -101,6 +113,8 @@ Node.JS
 nodejs
 Nodejs
 Objective-C
+openid connect
+Openid Connect
 Open InfiniBand
 Operating Environment
 Operating System
@@ -216,6 +230,9 @@ VT
 VT-i
 wan
 wca
+Webauthn
+webAuthn
+WebAuthN
 web-UI
 webUI
 Window-Maker

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -31,8 +31,10 @@ GNOME
 GNOME Classic
 GNU
 GPL
+GraalVM
 GRUB
 GTK+
+Hibernate ORM
 HP ProLiant
 Hyper-Threading
 hypervisor
@@ -53,18 +55,25 @@ ISO image
 Itanium
 Itanium 2
 JBoss Community
+JUnit
 JVM
 Kernel-based Virtual Machine
 Kickstart
 KVM
 LAN
 Linux
+Mandrel
+MicroProfile
 Microsoft
+MongoDB
 ms
 MS-DOS
+mutual TLS
+mTLS
 MySQL
 Node.js
 Objective C
+OpenID Connect
 operating environment
 operating system
 OperatorHub
@@ -123,6 +132,7 @@ VPN
 WAN
 WCA
 web UI
+WebAuthn
 Window Maker
 XEmacs
 xterm

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -8,6 +8,7 @@ btrfs
 centos
 Centos
 ceph
+Classloader
 crd
 ctrl
 Daemonset
@@ -16,6 +17,8 @@ dotnet
 endevor
 gluster
 gradle
+Graal VM
+graal vm
 gui
 homebrew
 Ide
@@ -32,6 +35,7 @@ lombok
 mattermost
 microsoft azure
 minikube
+Mongo DB
 Mysql
 mysql
 Netcoredebugoutput

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -39,6 +39,8 @@ Che
 Che-Theia
 Ciphertext
 Civetweb
+ClassLoader
+classpath
 classloading
 Classloading
 Cloudbursting
@@ -103,6 +105,7 @@ Git
 GitHub
 GitLab
 Gluster
+GraalVM
 Gradle
 Grafana
 Grayscale
@@ -138,8 +141,10 @@ Jolokia
 Journald
 Journaling
 Joyent
+JUnit
 jvm
 JVM
+Kafka
 kbd
 Keycloak
 Keyring
@@ -161,6 +166,7 @@ Matrixes
 Mattermost
 Maven
 Mebibytes
+MicroProfile
 Microsoft
 Middleware
 Millicores
@@ -170,6 +176,7 @@ Mirantis
 Mixin
 Mixins
 Modularization
+MongoDB
 Multicluster
 Multihost
 Multinode
@@ -193,6 +200,7 @@ OAuth
 ocp
 OmniSharp
 Onboarding
+OpenID
 OpenShift
 OpenTracing
 Operator
@@ -300,6 +308,7 @@ URLs
 Valgrind
 Velero
 vsix
+WebAuthn
 Webview
 Webviews
 Wildfly

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -41,6 +41,7 @@ swap:
   Gnome|gnome: GNOME
   Gnu|gnu: GNU
   Gpl|gpl: GPL
+  Graalvm|graalVM: GraalVM
   Grub: GRUB
   GTK|Gtk|gtk: GTK+
   HP Proliant: HP ProLiant
@@ -56,16 +57,21 @@ swap:
   iso: ISO
   Itanium2: Itanium 2
   JBoss.org: JBoss Community
+  Junit|junit: JUnit
   Jvm|jvm: JVM
   kernel-based virtual machine: Kernel-based Virtual Machine
   kickstart: Kickstart
   kvm: KVM
   Lan|lan: LAN
   LINUX|linux: Linux
+  Microprofile|micro-profile: MicroProfile
+  mongoDB|Mongodb|Mongo-db: MongoDB
   MS-dos|Ms-Dos|ms-dos|MSDOS|msdos: MS-DOS
   MS(?!-DOS?)|MSFT|MicroSoft: Microsoft
+  mutual tls|Mutual tls|Mutual TLS: mutual TLS
   MYSQL|mySQL: MySQL
   Objective-C: Objective C
+  openid connect|Openid Connect: OpenID Connect
   Open InfiniBand|Infiniband: InfiniBand
   Operating Environment: operating environment
   Operator Hub|Operator hub|Operatorhub|operatorhub: OperatorHub
@@ -130,6 +136,7 @@ swap:
   wan: WAN
   wca: WCA
   web-UI|webUI: web UI
+  Webauthn|webAuthn|WebAuthN: WebAuthn
   Window-Maker|WindowMaker: Window Maker
   Xemacs: XEmacs
   Xterm: xterm

--- a/.vale/styles/RedHat/Definitions.yml
+++ b/.vale/styles/RedHat/Definitions.yml
@@ -92,6 +92,7 @@ exceptions:
   - MB
   - MBR
   - MDS
+  - mTLS
   - NAT
   - NET
   - NFS

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -29,6 +29,8 @@ exceptions:
   - Che-Theia
   - Ciphertext
   - Civetweb
+  - ClassLoader
+  - Classloader
   - Cloudbursting
   - Cloudwashing
   - CodeReady
@@ -69,6 +71,7 @@ exceptions:
   - GitHub Action
   - GitLab
   - Gluster
+  - GraalVM
   - Gradle
   - Grayscale
   - GTKplus
@@ -76,6 +79,7 @@ exceptions:
   - Hashicorp
   - Helgrind
   - Helm
+  - Hibernate
   - Homebrew
   - HTTP
   - HTTPS
@@ -95,6 +99,7 @@ exceptions:
   - Jetbrains
   - Jolokia
   - Joyent
+  - JUnit
   - JVM
   - Kibana
   - Kompose
@@ -103,13 +108,17 @@ exceptions:
   - Laravel
   - Lombok
   - Makefile
+  - Mandrel
   - Mattermost
   - Maven
+  - MicroProfile
   - Microsoft
   - Middleware
   - Minikube
   - Minishift
   - Mirantis
+  - MongoDB
+  - mutual TLS
   - MySQL
   - Nagios
   - Neoverse
@@ -119,9 +128,11 @@ exceptions:
   - NuGet
   - OAuth
   - OmniSharp
+  - OpenID Connect
   - OpenShift
   - OpenTracing
   - OpEx
+  - ORM
   - PHP
   - Podman
   - PostgreSQL
@@ -167,6 +178,7 @@ exceptions:
   - Velero
   - vNIC
   - vNUMA
+  - WebAuthn
   - Webview
   - Webviews
   - Wildfly

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -151,6 +151,8 @@ filters:
   - Che-Theia
   - Ciphertext
   - Civetweb
+  - classloader
+  - classpath
   - Cloudbursting
   - Cloudwashing
   - CodeReady
@@ -189,6 +191,7 @@ filters:
   - Gluster
   - Gradle
   - Grayscale
+  - GraalVM
   - GUI
   - Hashicorp
   - Helgrind
@@ -212,8 +215,10 @@ filters:
   - Jetbrains
   - Jolokia
   - Joyent
+  - JUnit
   - jvm
   - JVM
+  - Kafka
   - kbd
   - Kibana
   - Kompose
@@ -224,11 +229,13 @@ filters:
   - Makefile
   - Mattermost
   - Maven
+  - MicroProfile
   - Microsoft
   - Middleware
   - Minikube
   - Minishift
   - Mirantis
+  - MongoDB
   - MySQL
   - Nagios
   - Neoverse
@@ -240,6 +247,7 @@ filters:
   - OAuth
   - ocp
   - OmniSharp
+  - OpenID
   - OpenShift
   - OpenTracing
   - osd
@@ -283,6 +291,7 @@ filters:
   - Valgrind
   - Velero
   - vsix
+  - WebAuthn
   - Webview
   - Webviews
   - Wildfly


### PR DESCRIPTION
The following names/services/components are regularly used in Java programming documentation in the Software industry but flag as spelling or capitalization errors by the Red Hat Vale rules. 

- classloader & ClassLoader
- classpath
- ~~foobar~~
- GraalVM
- Hibernate ORM
- JUnit
- Kafka
- Mandrel
- MicroProfile
- MongoDB
- mutual TLS (and initialism: mTLS)
- OpenID Connect
- WebAuthn

This PR adds those proper nouns to the spelling, heading, and capitalization style rules.

**Fixes:**
Lots of false positives, particularly in Runtimes product docs, for example, **Red Hat build of Quarkus**.
