### PR TITLE
fix: Remove 'knowledgebase' from TermErrors

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -151,6 +151,7 @@ Keycloak
 Keyring
 Keyrings
 Kibana
+knowledgebase
 Kompose
 Kubespray
 Kylin

--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -201,7 +201,6 @@ irrecoverable
 jar
 keep in mind
 kernelspace
-knowledgebase
 labour
 laptop
 large page

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -222,6 +222,7 @@ filters:
   - Kafka
   - kbd
   - Kibana
+  - knowledgebase
   - Kompose
   - Kubespray
   - Kylin

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -176,7 +176,6 @@ swap:
   jar: compress|archive
   keep in mind: remember
   kernelspace: kernel-space
-  knowledgebase: knowledge base
   labour: labor
   laptop: notebook
   large page|super page: huge page


### PR DESCRIPTION
This PR fixes the following false flags in the vale-at-red-hat linter output:

 RedHat.Spelling 7(292-305) Use correct American English spelling. Did you really mean 'Knowledgebase'?
❌ RedHat.TermsErrors 7(292-305) Use 'knowledge base' rather than 'Knowledgebase'.

**Why:**
The Red Hat supplementary style guide recommends the use of knowledgebase (without the space):

https://redhat-documentation.github.io/supplementary-style-guide/#rh-kb-links