### PR TITLE
feat: underscores in user-defined values

### DIFF
--- a/.vale/fixtures/RedHat/UserReplacedValues/.vale.ini
+++ b/.vale/fixtures/RedHat/UserReplacedValues/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `PassiveVoice` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.UserReplacedValues = YES

--- a/.vale/fixtures/RedHat/UserReplacedValues/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/UserReplacedValues/testinvalid.adoc
@@ -1,0 +1,5 @@
+This is __<a-user-replaced-value>__ with hyphens.
+This is __<a-user-replaced_value>__ with hyphens and underscores.
+This is __<a_user-replaced-value>__ with hyphens and undersores.
+This is __<a_user-replaced_value>__ with hyphens and underscores.
+This is __<a_user-`replaced`_value>__ with hyphens and monospaced.

--- a/.vale/fixtures/RedHat/UserReplacedValues/testvalid.adoc
+++ b/.vale/fixtures/RedHat/UserReplacedValues/testvalid.adoc
@@ -1,0 +1,3 @@
+This is __<a_user_replaced_value>__.
+This is __<{an-attribute-using-hyphens-in_a_user_replaced_value}>__.
+This is an hyphen, not in a user-replaced value.

--- a/.vale/styles/RedHat/UserReplacedValues.yml
+++ b/.vale/styles/RedHat/UserReplacedValues.yml
@@ -1,0 +1,8 @@
+---
+source: https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values
+extends: substitution
+message: '%s, rather than %s'
+level: suggestion
+scope: raw
+swap:
+  '__<[\w\x60]+-[\x60\w-]+>__': Separate words by underscores in user-replaced values

--- a/modules/reference-guide/nav.adoc
+++ b/modules/reference-guide/nav.adoc
@@ -14,6 +14,7 @@
 * xref:passivevoice.adoc[]
 * xref:readabilitygrade.adoc[]
 * xref:releasenotes.adoc[]
+* xref:repeatedwords.adoc[]
 * xref:sentencelength.adoc[]
 * xref:simplewords.adoc[]
 * xref:slash.adoc[]
@@ -23,3 +24,4 @@
 * xref:termssuggestions.adoc[]
 * xref:termswarnings.adoc[]
 * xref:usage.adoc[]
+* xref:userreplacedvalues.adoc[]

--- a/modules/reference-guide/pages/repeatedwords.adoc
+++ b/modules/reference-guide/pages/repeatedwords.adoc
@@ -1,0 +1,6 @@
+:navtitle: Repeated words
+:keywords: reference, rule, RepeatedWords
+
+= Repeated words
+
+Word is repeated.

--- a/modules/reference-guide/pages/userreplacedvalues.adoc
+++ b/modules/reference-guide/pages/userreplacedvalues.adoc
@@ -1,0 +1,15 @@
+:navtitle: User-replaced values
+:keywords: reference, rule, User-replaced values, Placeholders
+
+= User-replaced values
+
+Ensure that user-replaced values have the following characteristics:
+
+* Surrounded by angle brackets (`< >`)
+* Separated by underscores (`_) for multi-word values
+* Lowercase, unless the rest of the related text is uppercase or another capitalization scheme
+* Italicized
+* If the user-replaced value is referencing a value in code or in a command that is normally monospace, also use monospace for the user-replaced value
+
+.Additional resources
+* link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[User-replaced values]


### PR DESCRIPTION
Implements a subset of https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values. 

The rule uses the characteristics of user-replaced values (surrounded by brackets) to search for undesired hyphens.

The pull request also adds a missing documentation page for the `RepeatedWords` rule.

I chose the suggestion level as a starting alert level. It could be useful later to increase that level if the rule proves not to create false positives.

