### PR TITLE
Recommend to avoid self-referential text

### DIFF
--- a/.vale/fixtures/RedHat/SelfReferentialText/.vale.ini
+++ b/.vale/fixtures/RedHat/SelfReferentialText/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `SelfReferentialText` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.SelfReferentialText = YES

--- a/.vale/fixtures/RedHat/SelfReferentialText/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/SelfReferentialText/testinvalid.adoc
@@ -1,0 +1,11 @@
+This topic describes something.
+This module describes something.
+Follow the steps in this module to configure something.
+This assembly describes something.
+Follow the steps in this assembly to configure something.
+This chapter describes something.
+Follow the steps in this chapter to configure something.
+This section describes something.
+Follow the steps in this section to configure something.
+This subsection describes something.
+Follow the steps in this subsection to configure something.

--- a/.vale/styles/RedHat/SelfReferentialText.yml
+++ b/.vale/styles/RedHat/SelfReferentialText.yml
@@ -1,0 +1,14 @@
+---
+extends: existence
+ignorecase: true
+level: suggestion
+link: https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/selfreferentialtext/
+message: "Avoid using self-referential text such as '%s'."
+source: "IBM - Audience and medium, p. 22"
+tokens:
+  - this topic
+  - this module
+  - this assembly
+  - this chapter
+  - this section
+  - this subsection

--- a/modules/reference-guide/nav.adoc
+++ b/modules/reference-guide/nav.adoc
@@ -15,6 +15,7 @@
 * xref:readabilitygrade.adoc[]
 * xref:releasenotes.adoc[]
 * xref:repeatedwords.adoc[]
+* xref:selfreferentialtext.adoc[]
 * xref:sentencelength.adoc[]
 * xref:simplewords.adoc[]
 * xref:slash.adoc[]

--- a/modules/reference-guide/pages/selfreferentialtext.adoc
+++ b/modules/reference-guide/pages/selfreferentialtext.adoc
@@ -1,0 +1,10 @@
+:navtitle: Self-referential text
+:keywords: reference, rule, self-referential text
+
+= Self-referential text
+
+Avoid using self-referential text such as `This chapter` or `This module`.
+
+.Additional resources
+
+* link:{ibmsg-url-print}[{ibmsg-print} - Audience and medium, p. 22]


### PR DESCRIPTION
In the chapter about audience and medium, the IBM Style Guides recommends to avoid self-referential text like "this chapter" or "this topic" as much as possible. As this is particularly problematic in modular documentation where such text can theoretically appear anywhere in the document hierarchy, I added a vale style to report these as a suggestion.