### PR TITLE
removed 'on-premise' from termserrors

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -235,14 +235,12 @@ non-secure
 nonrecoverable
 nonsecure
 notion
-off-premise
 offline storage
 OK button
 okay
 on ramp
 on the fly
 on the other hand
-on-premise
 on-ramp
 oops
 op-code

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -195,12 +195,10 @@ not at the latest level
 not case-sensitive
 notebook
 now
-off-premises
 offline backup
 offsite
 OK
 omit
-on-premises
 onsite
 opcode
 open

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -2,3 +2,6 @@ he
 host name
 I
 she
+on premise
+on-premises
+on-prem

--- a/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
@@ -3,3 +3,6 @@ hostname
 I/O
 name
 you
+on-site
+in-house
+on-premise

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -204,14 +204,12 @@ swap:
   nonrecoverable: unrecoverable
   nonsecure|non-secure: insecure
   notion: concept
-  off-premise: on-premises|off-premises|onsite|offsite
   offline storage: auxiliary storage
   OK button: OK
   okay: OK
   on ramp: access method
   on the fly: dynamically|as needed|in real time|immediately
   on the other hand: however|alternatively|conversely
-  on-premise: on-premises|off-premises|onsite|offsite
   on-ramp: access method
   op-code: opcode
   open-source|OpenSource|opensource: open source

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -11,3 +11,4 @@ swap:
   "I(?!/O)": you
   he|she: you
   host name: hostname
+  on-premises|on-prem|on premise: on-premise|on-site|in-house


### PR DESCRIPTION
removed 'on-premise' from termserrors

'on site' is now listed as a warning

fixed #198 