### PR TITLE
Demoting crash from error to sugg

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -81,7 +81,6 @@ containerised
 context menu
 contextual help
 control-click
-crash
 cross platform
 cross site scripting
 crossplatform

--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -12,6 +12,7 @@ client side
 client-side
 Cloud
 code
+crash
 functionality
 input
 recommend

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -86,7 +86,6 @@ swap:
   containerised: containerized
   context menu: menu|pop-up menu
   contextual help: help|context-sensitive help
-  crash: fail|lock up|stop|stop responding
   cross site scripting: cross-site scripting
   crossplatform|cross platform: cross-platform
   CRUD: create retrieve update and delete

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -22,6 +22,7 @@ swap:
   channel: repository
   Cloud: cloud
   code: write
+  crash: fail|lock up|stop|stop responding
   functionality: functions # IBM
   input|type: enter (followed by the text to enter in monospace) # https://redhat-documentation.github.io/supplementary-style-guide/#text-entry
   recommend: direct users to take the recommended action


### PR DESCRIPTION
We currently list crash as an error term. This is incorrect. Crash in the verb form is incorrect, however, crash as a noun is acceptable in various usages. 

https://redhat-documentation.github.io/supplementary-style-guide/#crash

Demoting to Suggestion should fix for now. Ideally, we should catch with POS tagging only when crash is used as a verb. POS checking not possible with Vale rules - yet: https://github.com/errata-ai/vale-vscode/pull/60