### PR TITLE
Specify minimum Vale version needed for vale sync

### DIFF
--- a/modules/user-guide/pages/installing-vale-cli.adoc
+++ b/modules/user-guide/pages/installing-vale-cli.adoc
@@ -11,7 +11,7 @@
 [id="proc_using-vale-cli_{context}"]
 = Installing Vale with the `RedHat` package
 
-To use Vale CLI with the `RedHat` style on any project without further configuration in the projects: install and configure the Vale CLI.
+To use Vale CLI with the `RedHat` style on any project without further configuration in the projects: install and configure Vale CLI version 2.16.0 or later.
 
 .Procedure
 


### PR DESCRIPTION
The Packages feature of Vale was introduced from v 2.16.0.

**Fixes:**
If a Vale user already has an older version of Vale installed when they run 'vale sync' as outlined in step 2 they will get an error.