### PR TITLE
Simplify YAML regex

### DIFF
--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -143,4 +143,4 @@ swap:
   Window-Maker|WindowMaker: Window Maker
   Xemacs: XEmacs
   Xterm: xterm
-  '\s(?:[Yy]aml)|^(?:[Yy]aml)': YAML
+  '(?<!\.)yaml|Yaml': YAML


### PR DESCRIPTION
This PR simplifies the regex to catch `Yaml`, `yaml`, but not `xyz.yaml`. 