### PR TITLE
fix asciidoctor term error and error in repeated words test fextures

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -1,3 +1,7 @@
+Asciidoc
+asciidoc
+AsciiDoctor
+asciidoctor
 Bios
 btrfs
 burner

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -1,3 +1,5 @@
+AsciiDoc
+Asciidoctor
 /var
 BIND
 bind

--- a/.vale/fixtures/RedHat/RepeatedWords/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/RepeatedWords/testinvalid.adoc
@@ -1,15 +1,2 @@
-1. This is is a sentence with a repeated word.
-//      ----- is detected.
-
-2. This is a test test.
-//           ---------
-// `tokens` = '[^\s]+' does not detect it.
-// `tokens` = '[^\s\.]+' detects it.
-
-// 3. This is a test test,
-//              ---------
-// `tokens` = '[^\s\,]+' detects it, but neutralizes '[^\s\.]+' if placed above.
-
-// 4. Select the THE checkbox.
-//           ------- is detected if `ignorecase` is `true`.
-// However, I believe we should set it to `false`.
+This is is a sentence with a repeated word.
+This is a test test.

--- a/.vale/fixtures/RedHat/RepeatedWords/testvalid.adoc
+++ b/.vale/fixtures/RedHat/RepeatedWords/testvalid.adoc
@@ -1,17 +1,6 @@
-1. This is a sentence with two instances of a word.
-//         -                                -
-
-2. Allow searches to be performed on type, contributor, contributor type, and others.
-// In enumerations, commas should "break up" repetition.
-
-3. This is a Text. Text is nice.
-//           ----------
-// Upper-case word, punctuation, space, same case word.
-
-4. This is a text. Text is nice.
-//           ^^^^^^^^^^
-// lower-case word, punctuation, space, different case word.
-
-5. Select the THE checkbox.
-//        ------- is detected if `ignorecase` is `true`.
-// However, I believe we should set it to `false`.
+This is a sentence without a repeated word.
+This is a sentence with two instances of a word.
+Allow searches to be performed on type, contributor, contributor type, and others.
+This is a Text. Text is nice.
+This is a text. Text is nice.
+Select the THE checkbox.

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -1,10 +1,6 @@
 ansible
 antora
 api
-Asciidoc
-asciidoc
-AsciiDoctor
-asciidoctor
 bitbucket
 btrfs
 centos

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -6,8 +6,6 @@ Annobin
 Ansible
 Antora
 API
-AsciiDoc
-Asciidoctor
 autostart
 Autostart
 aws

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -8,6 +8,8 @@ source: "https://redhat-documentation.github.io/supplementary-style-guide/#gloss
 action:
   name: replace
 swap:
+  asciidoc|Asciidoc: AsciiDoc
+  asciidoctor|AsciiDoctor: Asciidoctor
   '[nN]odejs|[nN]ode\.JS|node\.js': Node.js
   # Bind: BIND
   Bios: BIOS

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -134,8 +134,6 @@ filters:
   - Ansible
   - Antora
   - API
-  - AsciiDoc
-  - Asciidoctor
   - aws
   - AWS
   - Azure


### PR DESCRIPTION
Tests were broken, they are now fixed by updating the following:

* Added AsciiDoc and Asciidoctor to CaseSensitiveTerms, removed from spelling
* Fixed test fixture for repeated words