### PR TITLE
removing CPU from usage errors

### DIFF
--- a/.vale/fixtures/RedHat/Usage/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Usage/testinvalid.adoc
@@ -39,7 +39,6 @@ connect
 consumability
 consume
 could
-CPU
 customers
 daughterboard
 decompress

--- a/.vale/styles/RedHat/Usage.yml
+++ b/.vale/styles/RedHat/Usage.yml
@@ -46,7 +46,6 @@ tokens:
   - consumability
   - consume
   - could
-  - CPU
   - customers
   - daughterboard
   - decompress


### PR DESCRIPTION
CPU is an accepted term in the ISG and SSG and should not be flagged: https://www.ibm.com/docs/en/ibm-style?topic=word-usage#c

