### PR TITLE
remove "tooling" from termserror

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -341,7 +341,6 @@ tier-one
 time-frame
 timeframe
 toggle off
-tooling
 top-left
 top-right
 topleft

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -291,6 +291,7 @@ tier-1
 time frame
 to
 toggle
+tooling
 tools
 touch-sensitive screen
 try again

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -279,7 +279,6 @@ swap:
   tier-one|tier 1: tier-1
   timeframe|time-frame: time frame
   toggle off: toggle
-  tooling: tools
   touchscreen: touch-sensitive screen
   typo: typing error|typographical error
   uncheck: clear


### PR DESCRIPTION
removing "tooling" from termserror as per https://github.com/redhat-documentation/vale-at-red-hat/issues/313