### PR TITLE
Changing rule level for "via" from error to warning

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -367,7 +367,6 @@ up-time
 upward compatible
 utilize
 versus
-via
 video-mode
 videomode
 virtualized

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -286,7 +286,6 @@ therefore
 thin-provisioned
 this clause that is restrictive
 this clause, which is nonrestrictive
-through
 tier-1
 time frame
 to

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -6,3 +6,4 @@ on premise
 on-premises
 on-prem
 tooling
+via

--- a/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
@@ -8,3 +8,8 @@ in-house
 on-premise
 tool
 tools
+through
+by
+from
+on
+by using

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -296,7 +296,6 @@ swap:
   upward compatible: compatible with later versions
   utilize: use
   versus: compared to
-  via: through
   video-mode|videomode: video mode
   virtualized: virtual
   vs: compared to

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -13,3 +13,4 @@ swap:
   host name: hostname
   on-premises|on-prem|on premise: on-premise|on-site|in-house
   tooling: tool|tools
+  via: through|by|from|on|by using


### PR DESCRIPTION
"via" is an acceptable term in the IBM style guide in certain contexts and should be downgraded from an error.

Closes https://github.com/redhat-documentation/vale-at-red-hat/issues/324


Moving from error level to warning level. 