### PR TITLE
'By using' gets incorrectly flagged depending on the surrounding context

### DIFF
--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -8,7 +8,7 @@ source: "https://redhat-documentation.github.io/supplementary-style-guide/glossa
 action:
   name: replace
 swap:
-  "(?<!by) using": by using|that uses
+  ".*(?<!by) using": by using|that uses
   "shell(?! prompt| script)": shell prompt
   ", that": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
   "(?<!,) which": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"


### PR DESCRIPTION
Addresses #208.

I think the term 'by using' gets flagged incorrectly depending on the surrounding context. If you play around with the testvalid.adoc for termsuggestions, you can generate an incorrect error on 'by using'. 

![image](https://user-images.githubusercontent.com/104497497/194538115-383de3ee-830c-4754-bf53-a3abcc8ab501.png)

See issue for more examples. I think it relates to what precedes the instance of 'by using'. Adding regex to allow anything before 'by' seems to fix this issue. 