### PR TITLE
[WIP] Convert JetBrains from a Spelling rule to a CaseSensitiveTerms rule?

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -85,6 +85,8 @@ iso
 iso image
 Itanium2
 JBoss.org
+jetbrains
+Jetbrains
 Junit
 junit
 jvm

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -59,6 +59,7 @@ ISO image
 Itanium
 Itanium 2
 JBoss Community
+JetBrains
 JUnit
 JVM
 Kernel-based Virtual Machine

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -25,7 +25,6 @@ infinispan
 Intellij
 Intellij IDEA
 lombok
-jetbrains
 Jvm
 kibana
 kubespray

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -140,7 +140,7 @@ Jakarta
 Java
 Jave
 JBoss
-Jetbrains
+JetBrains
 Jira
 Jolokia
 Journald

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -62,6 +62,7 @@ swap:
   iso: ISO
   Itanium2: Itanium 2
   JBoss.org: JBoss Community
+  jetbrains|Jetbrains: JetBrains
   Junit|junit: JUnit
   Jvm|jvm: JVM
   kernel-based virtual machine: Kernel-based Virtual Machine

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -100,7 +100,7 @@ exceptions:
   - Jakarta
   - Java
   - Jave
-  - Jetbrains
+  - JetBrains
   - Jira
   - Jolokia
   - Joyent

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -40,6 +40,7 @@ filters:
   - "[hH]yperconverged"
   - "[iI]node"
   - "[iI]tem"
+  - "[jJ]et[bB]rains"
   - "[jJ]ournald"
   - "[jJ]ournaling"
   - "[kK]eycloak"
@@ -214,7 +215,6 @@ filters:
   - Java
   - Jave
   - JBoss
-  - Jetbrains
   - Jira
   - Jolokia
   - Joyent


### PR DESCRIPTION
Reviewing https://github.com/redhat-documentation/vale-at-red-hat/pull/351, it seems like we should convert "JetBrains" from a Spelling rule to a CaseSensitiveTerms rule. WDYT?