### PR TITLE
feat: Add Spotify, GraphQL, and Quiltflower to spelling & heading rules

### DIFF
--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -10,4 +10,4 @@
 == Proof Key for Code Exchange
 == Kogito updates
 == IBM Cloud is a valid product name
-== Spotify and GraphQL are proper nouns so uppercase in headings is OK.
+== Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -10,3 +10,4 @@
 == Proof Key for Code Exchange
 == Kogito updates
 == IBM Cloud is a valid product name
+== Spotify and GraphQL are proper nouns so uppercase in headings is OK.

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -231,6 +231,7 @@ Pulldown
 Pytorch
 qeth
 Quarkus
+Quiltflower
 Readonly
 Rebalance
 Rebalances

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -112,6 +112,7 @@ Gluster
 GraalVM
 Gradle
 Grafana
+GraphQL
 Grayscale
 GUI
 Hashicorp
@@ -267,6 +268,7 @@ Sharding
 SLA
 SLAs
 SmallRye
+Spotify    
 startx
 su
 Subcommand

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -154,6 +154,7 @@ exceptions:
   - Pytorch
   - qeth
   - Quarkus
+  - Quiltflower
   - Red Hat
   - RedBoot
   - Redistributions

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -76,6 +76,7 @@ exceptions:
   - Gluster
   - GraalVM
   - Gradle
+  - GraphQL
   - Grayscale
   - GTKplus
   - GUI
@@ -164,6 +165,7 @@ exceptions:
   - Semeru
   - SmallRye
   - Shadowman
+  - Spotify
   - StarOffice
   - startx
   - Suchow

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -270,6 +270,7 @@ filters:
   - Pytorch
   - qeth
   - Quarkus
+  - Quiltflower
   - Redistributions
   - Restic
   - RESTEasy

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -196,6 +196,7 @@ filters:
   - Gradle
   - Grayscale
   - GraalVM
+  - GraphQL
   - GUI
   - Hashicorp
   - Helgrind
@@ -280,6 +281,7 @@ filters:
   - SLAs
   - Shadowman
   - SmallRye
+  - Spotify
   - startx
   - Suchow
   - SVG


### PR DESCRIPTION
'Spotify' , 'GraphQL', and Quiltflower are valid spellings and should also be capitalized in body text and headings.
Both flag up as false positive orange warnings in Quarkus product docs by the spelling and heading rules.
This PR fixes that.