### PR TITLE
Provide dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
part of #372

it will create the PR to update GitHub actions automatically. i t will contain the PR to update actions/checkout to a version recent enough to rely on Node 16 instead of Node 12 which is deprecated and planned for removal