### PR TITLE
chore: add YAML delimiter in all rules

### DIFF
--- a/.vale/styles/RedHat/RepeatedWords.yml
+++ b/.vale/styles/RedHat/RepeatedWords.yml
@@ -1,3 +1,4 @@
+---
 extends: repetition
 message: "'%s' is repeated!"
 level: warning


### PR DESCRIPTION
Add YAML delimiter (`---` line).

This is useful to concatenate all rules into a single YAML file for use with Grazie Professional on IntelliJ editors. See: https://plugins.jetbrains.com/plugin/16136-grazie-professional/docs/project-style-guides.html