### PR TITLE
Remove plugin from disallowed term list

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -256,8 +256,6 @@ perimeter network
 phone
 plain-text
 plaintext
-plugin
-plugins
 plug in
 plug ins
 pop-up blocker

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -209,8 +209,7 @@ parent process
 PC
 performance counter
 plain text
-plug-in
-plug-ins
+plugin
 point to
 pop-up menu
 power cable

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -7,5 +7,6 @@ she
 on premise
 on-premises
 on-prem
+plug-in
 tooling
 via

--- a/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
@@ -7,6 +7,7 @@ you
 on-site
 in-house
 on-premise
+plugin
 repository
 subscription
 tool

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -219,7 +219,7 @@ swap:
   perfcounter: performance counter
   perimeter network: DMZ
   plaintext|plain-text|cleartext|clear text: plain text
-  plugin|plugins|plug in|plug ins: plug-in # https://www.merriam-webster.com/dictionary/plug-in
+  plug in|plug ins: plugin
   power down: turn off
   power off: turn off
   power on: turn on

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -14,5 +14,7 @@ swap:
   may: might (for possiblity)|can (for ability) 
   on-premises|on-prem|on premise: on-premise|on-site|in-house
   entitlement: repository|subscription
+  plug-in: plugin
   tooling: tool|tools
   via: through|by|from|on|by using
+


### PR DESCRIPTION
The Red Hat Style Council recently revisited and updated the guidelines for using `plugin` and `plug-in` (noun & adjective forms) in Red Hat documentation, deviating from the ISG.

As per [RHSS issue 213](https://github.com/redhat-documentation/supplementary-style-guide/issues/213), `plugin` is  now the preferred form:

`Use "plugin" rather than "plug-in", unless you are updating existing content that uses the hyphenated form.`

This PR removes `plugin` from the Terms Errors rule and adds `plug-in` to the Terms Warnings rule.

This PR also removes the plural form, which was previously added to some of the rules/fixtures.