### PR TITLE
gh-387 adding a spelling exception for sysctl

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -268,6 +268,10 @@ SLA
 SLAs
 SmallRye
 startx
+sysctl
+sysctls
+Sysctls
+Sysctl
 su
 Subcommand
 Subcommands

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -98,6 +98,7 @@ filters:
   - "[sS]erializer"
   - "[sS]erverless"
   - "[sS]harding"
+  - "[sS]ysctl"
   - "[Ss]u"
   - "[sS]ubcommand"
   - "[sS]ubcommands"


### PR DESCRIPTION
Addressing GH issue 387