### PR TITLE
Add 'etcd' to case sensitive list

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -27,6 +27,8 @@ Disk druid
 diskdruid
 dns
 DVD burner
+ETCD
+Etcd
 Exec Shield
 exif
 EXIF

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -16,6 +16,7 @@ DevOps
 Disk Druid
 DNS
 DVD writer
+etcd
 Exec-Shield
 Exif
 FAQ

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -26,6 +26,7 @@ swap:
   Disk druid|disk druid|diskdruid: Disk Druid
   dns: DNS
   DVD burner|burner: DVD writer
+  Etcd|ETCD: etcd
   Exec Shield: Exec-Shield
   EXIF|exif: Exif
   Faq|faq|F.A.Q: FAQ


### PR DESCRIPTION
etcd is a key-store that contains information for distributed systems or a cluster of machines. As illustrated in this sentence, it is never presented in uppercase, even at the beginning of a sentence. Currently, etcd is not documented in any of our guides, but will be submitted for consideration in the appropriate place for reference purposes.

Allowed: etcd
Not allowed: Etcd, ETCD, etcD, ETCd, and all other iterations of capitalization.