### PR TITLE
Fix false positives in spelling and heading rules

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -1,3 +1,5 @@
+assertj
+Assertj
 Asciidoc
 asciidoc
 AsciiDoctor
@@ -92,6 +94,7 @@ junit
 jvm
 Jvm
 kernel-based virtual machine
+knowledgebase
 kickstart
 kvm
 lan
@@ -144,6 +147,8 @@ popup
 posix
 Posix
 Postscript
+Powershell
+powershell
 PPC
 PPC64
 ppp
@@ -247,6 +252,8 @@ wca
 Webauthn
 webAuthn
 WebAuthN
+Websocket
+websocket
 web-UI
 webUI
 Window-Maker

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -1,3 +1,4 @@
+AssertJ
 AsciiDoc
 Asciidoctor
 /var
@@ -63,6 +64,7 @@ JetBrains
 JUnit
 JVM
 Kernel-based Virtual Machine
+Knowledgebase
 Kickstart
 KVM
 LAN
@@ -88,6 +90,7 @@ pop-up
 POSIX
 PostScript
 PowerPC
+PowerShell
 PPP
 PROM
 Proof Key for Code Exchange
@@ -142,6 +145,7 @@ WAN
 WCA
 web UI
 WebAuthn
+WebSocket
 Window Maker
 XEmacs
 xterm

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -31,6 +31,8 @@ kubespray
 lombok
 mattermost
 microsoft azure
+mokitto
+mokito
 minikube
 Mysql
 mysql

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -1,11 +1,14 @@
 a .NET application
+accessor
 adoc
+Agroal
 Allowlist
 allowlist
 Annobin
 Ansible
 Antora
 API
+AssertJ
 autostart
 Autostart
 aws
@@ -14,14 +17,17 @@ Azure
 backfilling
 Backfilling
 backtrace
+backported
 Backtrace
 Bierner
 bindable
 Bindable
 Bitbucket
+BOM
 Bonjour
 boolean
 Boolean
+Bouncy Castle
 breakpoint
 Breakpoint
 breakpoints
@@ -67,6 +73,9 @@ Ctrl
 Cygmon
 DaemonSet
 Datadog
+declaratively
+decompiler
+deserialization
 Dev
 devfile
 Devfile
@@ -102,7 +111,10 @@ failback
 Failback
 failover
 Failover
+Failsafe
+Fernflower
 Fortran
+Funqy
 Gbps
 GCC
 Git
@@ -115,6 +127,7 @@ Grafana
 GraphQL
 Grayscale
 GUI
+hardcoding
 Hashicorp
 Heatmap
 Helgrind
@@ -138,6 +151,7 @@ IntelliJ
 Itanium
 Item
 Jakarta
+Jandex
 Java
 Jave
 JBoss
@@ -158,7 +172,7 @@ Keyring
 Keyrings
 Kibana
 Knative
-knowledgebase
+Knowledgebase
 Kogito
 Kompose
 Kubespray
@@ -179,6 +193,7 @@ Mebibytes
 MicroProfile
 Microsoft
 Middleware
+middleware
 Millicores
 Minikube
 Minishift
@@ -186,6 +201,7 @@ Mirantis
 Mixin
 Mixins
 Modularization
+Mockito
 MongoDB
 Multicluster
 Multihost
@@ -199,6 +215,7 @@ MySQL
 Nagios
 Namespace
 Namespaces
+Narayana
 Neoverse
 NetcoredebugOutput
 Netty
@@ -212,16 +229,22 @@ ocp
 OmniSharp
 Onboarding
 OpenID
+OpenJDK
 OpenShift
 OpenTracing
 Operator
 osd
+overridable
 PHP
 Podman
 PostgreSQL
+PowerShell
 preconfigured
 Preconfigured
 pregenerated
+prepended
+preconfigured
+prepend
 prepended
 productize
 productized
@@ -231,7 +254,9 @@ Pulldown
 Pytorch
 qeth
 Quarkus
+Quarkiverse
 Quiltflower
+Qute
 Readonly
 Rebalance
 Rebalances
@@ -263,8 +288,11 @@ SCM
 Scrollbar
 SELinux
 Semeru
+serialization
+serializable
 Serializer
 Serverless
+servlet
 Shadowman
 Sharding
 SLA
@@ -297,6 +325,7 @@ SVG
 Systemd
 Tekton
 Telekom
+Templated
 Tensorflow
 Texinfo
 Theia
@@ -323,10 +352,12 @@ url
 URL
 URLs
 Valgrind
+validator
 Velero
 Vert.x
 vsix
 WebAuthn
+WebSocket
 Webview
 Webviews
 Wildfly

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -8,6 +8,7 @@ source: "https://redhat-documentation.github.io/supplementary-style-guide/#gloss
 action:
   name: replace
 swap:
+  assertj|Assertj: AssertJ
   asciidoc|Asciidoc: AsciiDoc
   asciidoctor|AsciiDoctor: Asciidoctor
   '[nN]odejs|[nN]ode\.JS|node\.js': Node.js
@@ -67,6 +68,7 @@ swap:
   Jvm|jvm: JVM
   kernel-based virtual machine: Kernel-based Virtual Machine
   kickstart: Kickstart
+  knowledgebase: Knowledgebase
   kvm: KVM
   Lan|lan: LAN
   LINUX|linux: Linux
@@ -87,6 +89,7 @@ swap:
   popup|Pop-up: pop-up
   Posix|posix: POSIX
   Postscript: PostScript
+  Powershell|powershell: PowerShell
   PPC|P-PC|PPC64: PowerPC
   Ppp|ppp: PPP
   prom|Prom: PROM
@@ -147,6 +150,7 @@ swap:
   wca: WCA
   web-UI|webUI: web UI
   Webauthn|webAuthn|WebAuthN: WebAuthn
+  websocket|Websocket: WebSocket
   Window-Maker|WindowMaker: Window Maker
   Xemacs: XEmacs
   Xterm: xterm

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -9,18 +9,22 @@ source: "IBM - Capitalization in headings and titles, p.16"
 indicators:
   - ":"
 exceptions:
+  - Agroal
   - Annobin
   - Ansible
   - Antora
   - API
   - AsciiDoc
   - Asciidoctor
+  - AssertJ
   - AWS
   - Azure
   - Bierner
   - Bitbucket
+  - BOM
   - Bonjour
   - Btrfs
+  - Bouncy Castle
   - Bugzilla
   - Camel
   - CapEx
@@ -67,7 +71,10 @@ exceptions:
   - Esprima
   - Exif
   - Fabrice
+  - Failsafe
+  - Fernflower
   - Fortran
+  - Funqy
   - GCC
   - Git
   - GitHub
@@ -99,6 +106,7 @@ exceptions:
   - ISeries
   - Itanium
   - Jakarta
+  - Jandex
   - Java
   - Jave
   - JetBrains
@@ -109,6 +117,7 @@ exceptions:
   - JVM
   - Kibana
   - Knative
+  - Knowledgebase
   - Kogito
   - Kompose
   - Kubespray
@@ -125,10 +134,12 @@ exceptions:
   - Minikube
   - Minishift
   - Mirantis
+  - Mockito
   - MongoDB
   - mutual TLS
   - MySQL
   - Nagios
+  - Narayana
   - Neoverse
   - NetcoredebugOutput
   - Netty
@@ -138,6 +149,7 @@ exceptions:
   - OAuth
   - OmniSharp
   - OpenID Connect
+  - OpenJDK
   - OpenShift
   - OpenTracing
   - OpEx
@@ -147,6 +159,7 @@ exceptions:
   - PostgreSQL
   - PostScript
   - PowerPC
+  - PowerShell
   - Productize
   - Productized
   - Proof Key for Code Exchange
@@ -154,7 +167,9 @@ exceptions:
   - Pytorch
   - qeth
   - Quarkus
+  - Quarkiverse
   - Quiltflower
+  - Qute
   - Red Hat
   - RedBoot
   - Redistributions
@@ -194,6 +209,7 @@ exceptions:
   - WebAuthn
   - Webview
   - Webviews
+  - WebSocket
   - Wildfly
   - Window Maker
   - Woopra

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -10,9 +10,11 @@ filters:
   - '\.NET'
   - 'I/O'
   - 'Node\.js'
+  - "[aA]ccessor"
   - "[aA]llowlist"
   - "[aA]utostart"
   - "[bB]ackfilling"
+  - "[bB]ackported"
   - "[bB]acktrace"
   - "[bB]indable"
   - "[bB]oolean"
@@ -22,6 +24,9 @@ filters:
   - "[cC]lassloading"
   - "[cC]olocate"
   - "[cC]onfig"
+  - "[dD]eclaratively"
+  - "[dD]ecompiler"
+  - "[dD]eserialization"
   - "[dD]ev[wW]orkspace"
   - "[dD]evfile"
   - "[dD]evfiles"
@@ -35,6 +40,7 @@ filters:
   - "[gG]bps"
   - "[gG]it"
   - "[gG]rafana"
+  - "[hH]ardcoding"
   - "[hH]eatmap"
   - "[hH]ostname"
   - "[hH]yperconverged"
@@ -53,6 +59,7 @@ filters:
   - "[lL]oopback"
   - "[mM]atrixes"
   - "[mM]ebibytes"
+  - "[mM]iddleware"
   - "[mM]illicores"
   - "[mM]ixin"
   - "[mM]ixins"
@@ -68,9 +75,13 @@ filters:
   - "[nN]amespaces"
   - "[oO]nboarding"
   - "[oO]perator"
+  - "[oO]verridable"
   - "[pP]reconfigured"
   - "[pP]regenerated"
   - "[pP]ulldown"
+  - "[pP]reconfigured"
+  - "[pP]repend"
+  - "[pP]repended"
   - "[pP]roductize"
   - "[pP]roductized"
   - "[rR]eadonly"
@@ -96,7 +107,10 @@ filters:
   - "[rR]untimes"
   - "[sS]crollbar"
   - "[sS]erializer"
+  - "[sS]erialization"
+  - "[sS]erializable"
   - "[sS]erverless"
+  - "[sS]ervlet"
   - "[sS]harding"
   - "[Ss]u"
   - "[sS]ubcommand"
@@ -118,6 +132,7 @@ filters:
   - "[sS]ubvolume"
   - "[sS]ubvolumes"
   - "[sS]ystemd"
+  - "[tT]emplated"
   - "[tT]heia"
   - "[tT]olerations"
   - "[tT]raceback"
@@ -132,18 +147,23 @@ filters:
   - "[uU]ntrusted"
   - "[uU]psell"
   - "[uU]pselling"
+  - "[vV]alidator"
   - "Let\'s Encrypt"
   - adoc
+  - Agroal
   - Annobin
   - Ansible
   - Antora
   - API
+  - AssertJ
   - aws
   - AWS
   - Azure
   - Bierner
   - Bitbucket
+  - BOM
   - Bonjour
+  - Bouncy Castle
   - btn
   - Btrfs
   - Bugzilla
@@ -188,7 +208,10 @@ filters:
   - Esprima
   - Exif
   - Fabrice
+  - Failsafe
+  - Fernflower
   - Fortran
+  - Funqy
   - GCC
   - GitHub
   - GitLab
@@ -214,6 +237,7 @@ filters:
   - IntelliJ
   - Itanium
   - Jakarta
+  - Jandex
   - Java
   - Jave
   - JBoss
@@ -227,7 +251,7 @@ filters:
   - kbd
   - Kibana
   - Knative
-  - knowledgebase
+  - Knowledgebase
   - Kogito
   - Kompose
   - Kubespray
@@ -239,13 +263,14 @@ filters:
   - Maven
   - MicroProfile
   - Microsoft
-  - Middleware
   - Minikube
   - Minishift
   - Mirantis
+  - Mockito
   - MongoDB
   - MySQL
   - Nagios
+  - Narayana
   - Neoverse
   - NetcoredebugOutput
   - Netty
@@ -257,19 +282,21 @@ filters:
   - ocp
   - OmniSharp
   - OpenID
+  - OpenJDK
   - OpenShift
   - OpenTracing
   - osd
   - PHP
   - Podman
   - PostgreSQL
-  - preconfigured
-  - prepended
+  - PowerShell
   - Prometheus
   - proxied
   - Pytorch
   - qeth
   - Quarkus
+  - Quarkiverse
+  - Qute
   - Quiltflower
   - Redistributions
   - Restic
@@ -308,6 +335,7 @@ filters:
   - WebAuthn
   - Webview
   - Webviews
+  - WebSocket
   - Wildfly
   - Woopra
   - Wordpress


### PR DESCRIPTION
Updates to reduce the following false-positive orange warnings in the spelling, heading, and case-sensitive yml rulesets, which cause churn in the JAVA related developer documentation, especially within the Red Hat Runtimes products.


[aA]ccessor
[dD]eclaratively
[dD]ecompiler
[dD]eserialization
[hH]ardcoding
[mM]iddleware
[oO]verridable
[pP]preconfigured
[pP]prepend
[pP]prepended
[sS]erializer
[sS]erialization
[sS]erializable
[sS]ervlet
[tT]emplated
[vV]alidator
Agroal
AssertJ
BOM
BouncyCastle
Failsafe
Fernflower
Funqy
Jandex
Knowledgebase
Mockito
OpenJDK
PowerShell
Quarkiverse
Qute
WebSocket
