### PR TITLE
Demote verb error on JAR to a warning

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -89,6 +89,7 @@ iso
 iso image
 Itanium2
 JBoss.org
+jar file
 jetbrains
 Jetbrains
 Junit

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -60,6 +60,7 @@ ISO
 ISO image
 Itanium
 Itanium 2
+JAR file
 JBoss Community
 JetBrains
 JUnit

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -12,3 +12,4 @@
 == IBM Cloud is a valid product name
 == Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
 == Redis is an in-memory data structure store that is used by several Red Hat products.
+== Repackage the JAR file

--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -194,7 +194,6 @@ information technology
 insure
 Internet address
 irrecoverable
-jar
 keep in mind
 kernelspace
 labour
@@ -347,7 +346,6 @@ typo
 uncheck
 uncompress
 undeploy
-unjar
 unselect
 untar
 unzip

--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -15,6 +15,7 @@ code
 crash
 functionality
 input
+jar
 recommend
 refer to
 roll out
@@ -29,6 +30,7 @@ this clause which is nonrestrictive
 through
 thru
 type
+unjar
 user space
 user-space
 userspace

--- a/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
@@ -3,6 +3,8 @@ cloud
 compress
 enter
 functions
+JAR
+JAR file
 repository
 see
 segmentation fault

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -63,6 +63,7 @@ swap:
   iso image: ISO image
   iso: ISO
   Itanium2: Itanium 2
+  jar file: JAR file
   JBoss.org: JBoss Community
   jetbrains|Jetbrains: JetBrains
   Junit|junit: JUnit

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -107,6 +107,7 @@ exceptions:
   - Itanium
   - Jakarta
   - Jandex
+  - JAR file
   - Java
   - Jave
   - JetBrains

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -169,7 +169,6 @@ swap:
   insure: ensure
   Internet address: IP address|URL|Internet email address|web address
   irrecoverable: unrecoverable
-  jar: compress|archive
   keep in mind: remember
   kernelspace: kernel-space
   labour: labor
@@ -282,7 +281,6 @@ swap:
   uncheck: clear
   uncompress: decompress
   undeploy: remove|withdraw
-  unjar: extract
   unselect: clear|deselect
   untar: extract
   unzip: extract|decompress

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -25,12 +25,14 @@ swap:
   crash: fail|lock up|stop|stop responding
   functionality: functions # IBM
   input|type: enter (followed by the text to enter in monospace) # https://redhat-documentation.github.io/supplementary-style-guide/#text-entry
+  jar: compress|archive (verb)
   recommend: direct users to take the recommended action
   refer to: see
   roll-out|roll out|rollout: roll out (verb)|rollout (noun)
   segfault: segmentation fault
   tar: compress|archive
   thru|through: "' - ' (range)|by using|finished|completed"
+  unjar: extract (verb)
   user space|userspace|user-space: user space (noun)| user-space (modifier)
   zip: compress
   Navigate|navigate: '"click", "select", "browse", or "go to"'


### PR DESCRIPTION
JAR is incorrectly flagged as an error against non-verb word usage in the vale report with the guidance:  "Use 'compress' or 'archive' rather than 'JAR'. 

![image](https://user-images.githubusercontent.com/92924207/205302248-c88a24ef-39c0-4ad4-867a-fa982a4ef6c7.png)

In JAVA-related product docs, a task with lots of steps that include working with a JAR file, creates a lot of false-positive errors.

The style guideline for 'jar' relates to using jar/JAR as a verb, for example:
 **To _jar_ something** :

![image](https://user-images.githubusercontent.com/92924207/205302419-aa2e4c50-c64c-4f69-8ad2-59dc8bed7e28.png)

This PR demotes the error to a suggestion and adds (verb) clarification. The PR also adds "JAR file" as a permitted exception.