### PR TITLE
Add Redis to spelling, heading and case rules

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -180,6 +180,7 @@ Red Hat Satellite server
 Red Hat Satellite Capsule server
 Red Hat Network Satellite server
 Redboot
+redis
 resteasy
 Resteasy
 RESTEASY

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -107,6 +107,7 @@ Red Hat Satellite Server
 Red Hat Satellite Capsule Server
 Red Hat Network Satellite Server
 RedBoot
+Redis
 RESTEasy
 ROM
 RPM

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -11,3 +11,4 @@
 == Kogito updates
 == IBM Cloud is a valid product name
 == Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
+== Redis is an in-memory data structure store that is used by several Red Hat products.

--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -48,6 +48,7 @@ Postgresql
 postgres
 podman
 quarkus
+redis
 restic
 Sbt
 scm

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -265,6 +265,7 @@ Rebase
 Rebased
 Recertification
 Recertifications
+Redis
 Redistributions
 Reshard
 Resharding

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -108,6 +108,7 @@ swap:
   Red Hat Satellite Capsule server: Red Hat Satellite Capsule Server
   Red Hat Network Satellite server: Red Hat Network Satellite Server
   Redboot|Red Boot: RedBoot
+  redis: Redis
   RESTEASY|resteasy|Resteasy: RESTEasy
   Rom|rom: ROM
   rpm: RPM

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -171,6 +171,7 @@ exceptions:
   - Quiltflower
   - Qute
   - Red Hat
+  - Redis
   - RedBoot
   - Redistributions
   - RESTEasy

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -299,6 +299,7 @@ filters:
   - Quarkiverse
   - Qute
   - Quiltflower
+  - Redis
   - Redistributions
   - Restic
   - RESTEasy


### PR DESCRIPTION
Fixes: The false positive spelling warning on content containing the proper noun 'Redis, which is a technology that is used by several Red Hat Runtimes products.

Reference: https://redis.io/
