### PR TITLE
feat: fix false positives in the Headings rule  found in Flatpak docs

### DIFF
--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -16,3 +16,12 @@
 == Installing Podman Desktop
 == Installing Flathub
 == Installing Flatpak
+== Flatpak Builder
+== Software Development Kit
+== Software Development Kits
+== Application IDs
+== AppData files
+== The Electron base app
+== The Node.js SDK extension
+== Instructions for GTK
+== Instructions for Qt

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -9,29 +9,33 @@ source: "IBM - Capitalization in headings and titles, p.16"
 indicators:
   - ":"
 exceptions:
+  - API
+  - AWS
   - Agroal
   - Annobin
   - Ansible
   - Antora
-  - API
+  - AppData
   - AsciiDoc
   - Asciidoctor
   - AssertJ
-  - AWS
   - Azure
+  - BOM
   - Bierner
   - Bitbucket
-  - BOM
   - Bonjour
-  - Btrfs
   - Bouncy Castle
+  - Btrfs
   - Bugzilla
+  - CDs
+  - CR
+  - CRD
+  - CRDs
+  - CRs
   - Camel
   - CapEx
-  - CDs
   - CentOS
   - Ceph
-  - cgroup
   - Che-Theia
   - Ciphertext
   - Civetweb
@@ -46,28 +50,24 @@ exceptions:
   - Containerfile
   - Containerfiles
   - Cookiecutter
-  - CR
-  - CRD
-  - CRDs
-  - CRs
   - Ctrl
   - Cygmon
+  - DNS
   - DaemonSet
   - Datadog
   - Dev
   - DevOps
   - DevWorkspace
   - Dex
-  - DNS
   - Docker
   - Dockerfile
   - Dockerfiles
   - Dotnet
-  - Eclipse
   - Dyninst
+  - Eclipse
+  - Electron
   - Endevor
   - Endian
-  - eServer
   - Esprima
   - Exif
   - Fabrice
@@ -75,49 +75,54 @@ exceptions:
   - Fernflower
   - Flathub
   - Flatpak
+  - Flatpak Builder
   - Fortran
   - Funqy
   - GCC
+  - GTKplus
+  - GUI
   - Git
   - GitHub
   - GitHub Action
   - GitLab
+  - GitLab Code Quality
   - Gluster
   - GraalVM
   - Gradle
   - GraphQL
   - Grayscale
-  - GTKplus
-  - GUI
+  - GTK
+  - HTTP
+  - HTTPS
   - Hashicorp
   - Helgrind
   - Helm
   - Hibernate
   - Homebrew
-  - HTTP
-  - HTTPS
   - IBM
   - IBM Cloud
+  - ID
   - IDE
   - IDEs
+  - IDs
+  - IPSec
+  - ISeries
   - InfiniBand
   - Infinispan
   - Intelephense
   - IntelliJ
-  - IPSec
-  - ISeries
   - Itanium
+  - JAR file
+  - JUnit
+  - JVM
   - Jakarta
   - Jandex
-  - JAR file
   - Java
   - Jave
   - JetBrains
   - Jira
   - Jolokia
   - Joyent
-  - JUnit
-  - JVM
   - Kibana
   - Knative
   - Knowledgebase
@@ -139,7 +144,6 @@ exceptions:
   - Mirantis
   - Mockito
   - MongoDB
-  - mutual TLS
   - MySQL
   - Nagios
   - Narayana
@@ -148,80 +152,87 @@ exceptions:
   - Netty
   - Newdoc
   - Nginx
+  - Node.js
   - NuGet
   - OAuth
+  - ORM
   - OmniSharp
+  - OpEx
   - OpenID Connect
   - OpenJDK
   - OpenShift
   - OpenTracing
-  - OpEx
-  - ORM
   - PHP
   - Podman
   - Podman Desktop
-  - PostgreSQL
   - PostScript
+  - PostgreSQL
   - PowerPC
   - PowerShell
   - Productize
   - Productized
-  - Proof Key for Code Exchange
   - Prometheus
+  - Proof Key for Code Exchange
   - Pytorch
-  - qeth
-  - Quarkus
+  - Qt
   - Quarkiverse
+  - Quarkus
   - Quiltflower
   - Qute
-  - Red Hat
-  - Redis
-  - RedBoot
-  - Redistributions
   - RESTEasy
+  - Red Hat
+  - RedBoot
+  - Redis
+  - Redistributions
   - Rolfe
-  - Sakila
   - SCM
+  - SDK
   - SELinux
+  - SVG
+  - Sakila
   - Semeru
-  - SmallRye
   - Shadowman
+  - SmallRye
+  - Software Development Kit
+  - Software Development Kits
   - Spotify
   - StarOffice
-  - startx
   - Suchow
-  - SVG
-  - System
   - SysV
+  - System
   - Tekton
   - Telekom
   - Tensorflow
   - Texinfo
   - Toolset
   - Traefik
-  - Uber
-  - UltraSPARC
   - URI
   - URIs
   - URL
   - URLs
+  - Uber
+  - UltraSPARC
   - Vale
   - Valgrind
   - Velero
   - Vert.x
-  - vNIC
-  - vNUMA
   - WebAuthn
+  - WebSocket
   - Webview
   - Webviews
-  - WebSocket
   - Wildfly
   - Window Maker
   - Woopra
   - Wordpress
   - XEmacs
-  - xterm
   - Yana
   - Yeoman
   - Zowe
-  - GitLab Code Quality
+  - cgroup
+  - eServer
+  - mutual TLS
+  - qeth
+  - startx
+  - vNIC
+  - vNUMA
+  - xterm


### PR DESCRIPTION
Fixes false positives in the Headings rule found in Flatpak docs (product names).

For reference: all Headings alerts in Flatpak docs:
 

```
 vale . --output line | grep Headings
docs/building-introduction.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Building Introduction'.
docs/building-introduction.rst:8:1:RedHat.Headings:Use sentence-style capitalization in 'flatpak-builder'.
docs/building-introduction.rst:44:1:RedHat.Headings:Use sentence-style capitalization in 'Software Development Kits (SDKs)'.
README.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'flatpak-docs'.
docs/available-runtimes.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Available Runtimes'.
docs/available-runtimes.rst:127:1:RedHat.Headings:Use sentence-style capitalization in 'elementary'.
docs/debugging.rst:52:1:RedHat.Headings:Use sentence-style capitalization in 'Creating a .Debug extension'.
docs/conventions.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Requirements & Conventions'.
docs/conventions.rst:13:1:RedHat.Headings:Use sentence-style capitalization in 'Expected Standards'.
docs/conventions.rst:20:1:RedHat.Headings:Use sentence-style capitalization in 'Application IDs'.
docs/conventions.rst:66:1:RedHat.Headings:Use sentence-style capitalization in 'AppData files'.
docs/electron.rst:58:1:RedHat.Headings:Use sentence-style capitalization in 'The Electron base app'.
docs/electron.rst:75:1:RedHat.Headings:Use sentence-style capitalization in 'The Node.js SDK extension'.
docs/desktop-integration.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Desktop Integration'.
docs/desktop-integration.rst:130:1:RedHat.Headings:Use sentence-style capitalization in 'Instructions for Gtk'.
docs/desktop-integration.rst:141:1:RedHat.Headings:Use sentence-style capitalization in 'Instructions for Qt'.
docs/flatpak-builder-command-reference.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Flatpak Builder Command Reference'.
docs/flatpak-command-reference.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Flatpak Command Reference'.
docs/flatpak-builder.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Flatpak Builder'.
docs/first-build.rst:27:1:RedHat.Headings:Use sentence-style capitalization in '2. Create the app'.
docs/first-build.rst:38:1:RedHat.Headings:Use sentence-style capitalization in '3. Add a manifest'.
docs/first-build.rst:69:1:RedHat.Headings:Use sentence-style capitalization in '4. Build the application'.
docs/first-build.rst:80:1:RedHat.Headings:Use sentence-style capitalization in '5. Test the build'.
docs/first-build.rst:112:1:RedHat.Headings:Use sentence-style capitalization in '7. Install the app'.
docs/first-build.rst:132:1:RedHat.Headings:Use sentence-style capitalization in '8. Run the app'.
docs/getting-started.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Getting Started'.
docs/hosting-a-repository.rst:27:1:RedHat.Headings:Use sentence-style capitalization in '.flatpakrepo files'.
docs/libflatpak-api-reference.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'libflatpak API Reference'.
docs/portal-api-reference.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Portal API Reference'.
docs/manifests.rst:184:1:RedHat.Headings:Use sentence-style capitalization in 'Shared Modules'.
docs/manifests.rst:217:1:RedHat.Headings:Use sentence-style capitalization in 'Flatpak Builder Tools'.
docs/python.rst:38:1:RedHat.Headings:Use sentence-style capitalization in 'Building multiple Python dependencies'.
docs/reference.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Reference Documentation'.
docs/repositories.rst:24:1:RedHat.Headings:Use sentence-style capitalization in '.flatpakref files'.
docs/sandbox-permissions-reference.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Sandbox Permissions Reference'.
docs/tips-and-tricks.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Tips and Tricks'.
docs/under-the-hood.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Under the Hood'.
docs/sandbox-permissions.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'Sandbox Permissions'.
docs/sandbox-permissions.rst:166:1:RedHat.Headings:Use sentence-style capitalization in 'dconf access'.
docs/sandbox-permissions.rst:192:1:RedHat.Headings:Use sentence-style capitalization in 'gvfs access'.
docs/usb-drives.rst:1:1:RedHat.Headings:Use sentence-style capitalization in 'USB Drives'.
```