### PR TITLE
Enhance passive voice rule message.

### DIFF
--- a/.vale/styles/RedHat/PassiveVoice.yml
+++ b/.vale/styles/RedHat/PassiveVoice.yml
@@ -3,7 +3,7 @@ extends: existence
 ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/passivevoice/
-message: "'%s' is passive voice. Consider rewording in active voice. You can use the passive voice in prerequisites"
+message: "'%s' is passive voice. In general, use active voice. Consult the style guide for acceptable use of passive voice."
 source: "https://redhat-documentation.github.io/supplementary-style-guide/#prerequisites; IBM - Voice, p.35"
 raw:
   - \b(am|are|were|being|is|been|was|be)\b\s*


### PR DESCRIPTION
**Problem:**
The existing message that is presented when passive voice is detected suggests only one of the acceptable uses that our style guidelines call out. 

![image](https://user-images.githubusercontent.com/92924207/211018898-196c52e7-8067-452f-bf10-d97748e72694.png)

This PR adjusts the detail in the message to remove the detailed prerequisites guidance:

![image](https://user-images.githubusercontent.com/92924207/211017841-cee56c5a-c119-46ed-9ef1-233f7d63aeab.png)
