### PR TITLE
Adding rule to flag IPI, UPI and AI acronyms

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -8,6 +8,7 @@ a transition
 abort
 administrate
 advisor
+AI
 air wall
 all caps
 all right
@@ -194,6 +195,7 @@ information on
 information technology
 insure
 Internet address
+IPI
 irrecoverable
 keep in mind
 kernelspace
@@ -359,6 +361,7 @@ up-sell
 up-selling
 up-stream
 up-time
+UPI
 upward compatible
 utilize
 versus

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -14,6 +14,7 @@ as
 as expected
 as in
 as needed
+Assisted Installer
 attention notice
 auto-detect
 auxiliary storage
@@ -148,6 +149,7 @@ includes
 information about
 insecure
 installation program
+installer-provisioned infrastructure
 interface
 interim fix
 Internet email address
@@ -318,6 +320,7 @@ URL
 USB flash drive
 use
 user
+user-provisioned infrastructure
 verify
 version
 video mode

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -19,6 +19,7 @@ swap:
   "(?<!Mozilla )Firefox": Mozilla Firefox
   "(?<!Mozilla )Thunderbird": Mozilla Thunderbird
   "a lot(?: of)?": many|much
+  "AI": Assisted Installer
   "backward(?:-)?compatible": compatible with earlier versions
   "[bB]asic [aA]uth": Basic HTTP authentication (first instance)|Basic authentication
   "bottle neck|bottle-neck": bottleneck
@@ -26,6 +27,7 @@ swap:
   "bottom(?:-)?right": lower right|lower-right
   "broad cast|broad-cast": broadcast
   "down(?:-)?level": earlier|previous|not at the latest level
+  "IPI": installer-provisioned infrastructure
   "mash(?: )?up": create
   "non-English(?!-language?)": in languages other than English|non-English-language
   "pop-up (?:blocker|killer)": software to block pop-up ad windows
@@ -33,6 +35,7 @@ swap:
   "sort(?:-|/)?merge": sort|merge
   "top(?:-)?left": upper left|upper right|upper-left|upper-right
   "top(?:-)?right": upper left|upper right|upper-left|upper-right
+  "UPI": user-provisioned infrastructure
   # "app(?:.)": app
   a number of: several
   abort: cancel|stop


### PR DESCRIPTION
We should not use UPI or IPI acronyms in the docs according to the [SSG](https://redhat-documentation.github.io/supplementary-style-guide/). Instead use "installer-provisioned infrastructure" and "user-provisioned infrastructure". 

I am pretty certain the same goes for Assisted Installer although there is no official guidance. I opened an issue to follow up with that. I did check with the Assisted Installer writers and AI should be avoided - obvious confusion with artificial intelligence. I think it's pretty safe to add AI here too. 