### PR TITLE
Add a warning for words 'sane' and 'sanity'

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -285,6 +285,7 @@ run level
 run-level
 S 390
 sanity check
+sanity test
 screensaver
 scroll bar
 scroll-bar

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -9,6 +9,7 @@ on premise
 on-premises
 on-prem
 plug-in
+sane
 tooling
 via
 BIOS

--- a/.vale/fixtures/RedHat/Usage/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Usage/testinvalid.adoc
@@ -110,6 +110,7 @@ repair
 reside
 respective
 respectively
+sanity
 select
 selected
 should

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -240,7 +240,8 @@ swap:
   round table: roundtable
   rule of thumb: rule
   run level|run-level: runlevel
-  sanity check: test|evaluate
+  sanity check: test|evaluate|validate|verify
+  sanity test: test|evaluate|validate|verify
   screensaver: screen saver
   scroll bar|scroll-bar: scrollbar
   secondary storage: auxiliary storage

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -16,6 +16,7 @@ swap:
   on-premises|on-prem|on premise: on-premise|on-site|in-house
   entitlement: repository|subscription
   plug-in: plugin
+  sane: accurate|valid|verified
   tooling: tool|tools
   via: through|by|from|on|by using
   BIOS: firmware

--- a/.vale/styles/RedHat/Usage.yml
+++ b/.vale/styles/RedHat/Usage.yml
@@ -117,6 +117,7 @@ tokens:
   - reside
   - respective
   - respectively
+  - sanity
   - select
   - selected
   - should


### PR DESCRIPTION
In the Word Usage section, the IBM Style Guide recommends to avoid the use of word 'sane' as it might be offensive to neurodiverse people. As it provides alternatives, I added it to TermsWarnings to provide a warning.

In addition, the IBM Style Guide recommends to avoid using the phrases 'sanity check' and 'sanity test'. There already is a rule for 'sanity check' but for completeness and to honor the intent behind these recommendations, I added a warning for 'sanity test' and 'sanity' as well.