### PR TITLE
Remove "due to" fixes #417

### DIFF
--- a/.vale/fixtures/RedHat/Usage/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Usage/testinvalid.adoc
@@ -47,7 +47,6 @@ designed to
 display
 domestic
 done
-due to
 either
 EPUB
 execute

--- a/.vale/styles/RedHat/Usage.yml
+++ b/.vale/styles/RedHat/Usage.yml
@@ -54,7 +54,6 @@ tokens:
   - display
   - domestic
   - done
-  - due to
   - either
   - EPUB
   - execute


### PR DESCRIPTION
I verified that the IBM Style does not have a guideline for "due to".