### PR TITLE
Ensure the correct spelling of OpenShift

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -260,6 +260,7 @@ on-ramp
 oops
 op-code
 open-source
+OpenShit
 OpenSource
 opensource
 organise

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -220,6 +220,7 @@ onsite
 opcode
 open
 open source
+OpenShift
 override
 parent process
 PC

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -224,6 +224,7 @@ swap:
   on the other hand: however|alternatively|conversely
   on-ramp: access method
   op-code: opcode
+  openshit: OpenShift
   open-source|OpenSource|opensource: open source
   organise: organize
   organised: organized


### PR DESCRIPTION
An unfortunate typo sadly occasionally makes it to published documentation. Adding it to Vale increases author's chances of catching it early.