### PR TITLE
Turn off PascalCamel case rule in headings

### DIFF
--- a/.vale/fixtures/RedHat/PascalCamelCase/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testinvalid.adoc
@@ -1,4 +1,3 @@
-APIServer
 APIService
 BareMetalHost
 BrokerTemplateInstance
@@ -127,5 +126,4 @@ VolumeSnapshot
 VolumeSnapshotClass
 VolumeSnapshotContent
 xmlHttpRequest is a camel case term.
-youTubeImporter
-youtubeImporter
+. youTubeImporter is a camel case term in a list.

--- a/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
@@ -1,3 +1,4 @@
+== camelCase term should not be flagged in headings
 3scale
 AGPLv
 AMQ
@@ -127,6 +128,7 @@ Words at the start of a sentence should not trigger the rule.
 xPaaS
 XString
 XWayland
+YouTube
 ZCentral
 
 [source,terminal]

--- a/.vale/styles/RedHat/PascalCamelCase.yml
+++ b/.vale/styles/RedHat/PascalCamelCase.yml
@@ -2,6 +2,7 @@
 extends: existence
 ignorecase: false
 level: suggestion
+scope: [list, sentence]
 link: https://redhat-documentation.github.io/asciidoc-markup-conventions
 message: "Consider wrapping this Pascal or Camel case term ('%s') in backticks."
 source: https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles/RedHat/PascalCamelCase.yml
@@ -124,4 +125,5 @@ exceptions:
   - xPaaS
   - XString
   - XWayland
+  - YouTube
   - ZCentral


### PR DESCRIPTION
Turn off PascalCamel case rule in headings by using `scope: [list, sentence]` in the rule. 