### PR TITLE
feat: 'Podman Desktop' and 'Certificate Authorities (CA)' are correct in a title

### DIFF
--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -31,3 +31,6 @@
 == Instructions for Qt
 == Running Kind on Windows Subsystem for Linux (WSL)
 == Technology Preview
+== Using Podman Desktop
+== Using a proxy requiring custom Certificate Authorities
+== Using a proxy requiring custom Certificate Authorities (CA)

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -38,6 +38,7 @@ exceptions:
   - CapEx
   - CentOS
   - Ceph
+  - Certificate Authorities
   - Che-Theia
   - Ciphertext
   - Civetweb


### PR DESCRIPTION
* Added exceptions to the `RedHat.Headings` rule
* fixes https://github.com/redhat-documentation/vale-at-red-hat/issues/455
* unblocks https://github.com/containers/podman-desktop/pull/1541