### PR TITLE
feat: 'Windows' is correct, it is not necessarly followed by 'Server'

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -258,7 +258,6 @@ micro-profile
 Microprofile
 MicroSoft
 Microsoft Azure Portal
-Microsoft Windows
 Microsoft Windows Server
 MoM
 Mom
@@ -506,7 +505,6 @@ websocket
 webUI
 Window-Maker
 WindowMaker
-Windows
 x-plat cli
 X-PLAT CLI
 x-plat-cli

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -286,6 +286,7 @@ web UI
 WebAuthn
 WebSocket
 Window Maker
+Windows
 Windows Server
 XEmacs
 XP

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -173,7 +173,7 @@ swap:
   master server: IdM server and replicas
   Microprofile|micro-profile: MicroProfile
   Microsoft Azure Portal: Microsoft Azure portal
-  Microsoft Windows Server|Microsoft Windows|Windows(?! Server): Windows Server
+  Microsoft Windows Server: Windows Server
   MoM|Mom|mom: MOM
   Mongo\sDB|mongoDB|Mongodb|Mongo-db: MongoDB
   MS(?!-DOS?)|MSFT|MicroSoft: Microsoft


### PR DESCRIPTION
* fixes https://github.com/redhat-documentation/vale-at-red-hat/issues/458
* unblocks https://github.com/containers/podman-desktop/pull/1541