### PR TITLE
Updating workflows - save-state and set-output commands are deprecated

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -36,7 +36,7 @@ jobs:
       # See: http://man7.org/linux/man-pages/man1/date.1.html
       - name: Get yearweek for cache
         id: get-date # used below
-        run: echo "::set-output name=yearweek::$(/bin/date -u "+%Y%U")"
+        run: echo "yearweek=$(/bin/date -u "+%Y%U")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore cache
         uses: actions/cache@v3

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "::set-output name=pr_number::$(<PR_NUMBER)"
-          echo "::set-output name=pr_sha::$(<PR_SHA)"
-          echo "::set-output name=deploy_domain::$(echo ${{ github.repository }}-$(<PR_NUMBER).surge.sh | sed s#/#-#)"
-          echo "::set-output name=project::$(find build/ -mindepth 1 -maxdepth 1  -type d)"
+          echo "pr_number=$(<PR_NUMBER)" >> $GITHUB_OUTPUT
+          echo "pr_sha=$(<PR_SHA)" >> $GITHUB_OUTPUT
+          echo "deploy_domain=$(echo ${{ github.repository }}-$(<PR_NUMBER).surge.sh | sed s#/#-#)" >> $GITHUB_OUTPUT
+          echo "project=$(find build/ -mindepth 1 -maxdepth 1  -type d)" >> $GITHUB_OUTPUT
       - name: Deploy
         id: deploy
         env:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 