### PR TITLE
"Amazon Web Services" should not flag as an error term

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -485,15 +485,12 @@ VT
 VT-i
 wan
 wca
-web services
-Web Services
 web-UI
 webadmin
 webadmin portal
 Webauthn
 webAuthn
 WebAuthN
-webservices
 Websocket
 websocket
 webUI

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -2,6 +2,7 @@
 /var
 ACK flag
 Administration Portal
+Amazon Web Services
 AMQ
 AMQ Broker
 AMQ Clients

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -288,7 +288,6 @@ swap:
   wca: WCA
   web-UI|webUI: web UI
   Webauthn|webAuthn|WebAuthN: WebAuthn
-  webservices|web services|Web Services: Web services
   websocket|Websocket: WebSocket
   Window-Maker|WindowMaker: Window Maker
   Xemacs: XEmacs


### PR DESCRIPTION
Remove the `webservices|web services|Web Services: Web services` rule altogether. It is misleading outside of JBoss EAP docs.

Context: 
* https://redhat-internal.slack.com/archives/C04HKR61MN1/p1678368726101069
* https://redhat-internal.slack.com/archives/C0218RXJK5E/p1678354141706229