### PR TITLE
Do not report errors for DM Multipath

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -58,6 +58,7 @@ DevOps
 Directory Manager
 Directory Server
 Disk Druid
+DM Multipath
 DNS
 DVD writer
 Editor

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -59,6 +59,7 @@ Directory Manager
 Directory Server
 Disk Druid
 DM Multipath
+DM-Multipath
 DNS
 DVD writer
 Editor

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -33,7 +33,7 @@ swap:
   'Admin\sPortal|webadmin\sportal|webadmin|Administrator\sPortal|Administration\sportal': Administration Portal
   'BPMS|(?<!Red Hat )JBoss BPMS|(?<!Red Hat JBoss )BPM(?! Suite)': Red Hat JBoss BPM Suite
   'BRMS\sengine': inference engine
-  'DM(?! Multipath)|directory manager': Directory Manager
+  'DM(?![ -]Multipath)|directory manager': Directory Manager
   'GUI\seditor|Business\sCentral\seditor': guided editor
   'JBoss Broker|Red Hat Broker|The AMQ Broker': AMQ Broker
   'JBoss Console|Red Hat Console': AMQ Console

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -33,6 +33,7 @@ swap:
   'Admin\sPortal|webadmin\sportal|webadmin|Administrator\sPortal|Administration\sportal': Administration Portal
   'BPMS|(?<!Red Hat )JBoss BPMS|(?<!Red Hat JBoss )BPM(?! Suite)': Red Hat JBoss BPM Suite
   'BRMS\sengine': inference engine
+  'DM(?! Multipath)|directory manager': Directory Manager
   'GUI\seditor|Business\sCentral\seditor': guided editor
   'JBoss Broker|Red Hat Broker|The AMQ Broker': AMQ Broker
   'JBoss Console|Red Hat Console': AMQ Console
@@ -93,7 +94,6 @@ swap:
   devops|Devops|Dev-Ops|Dev Ops: DevOps
   directory server: Directory Server
   Disk druid|disk druid|diskdruid: Disk Druid
-  DM|directory manager: Directory Manager
   dns: DNS
   DVD burner|burner: DVD writer
   DWH|data warehouse|Dataware House: Data Warehouse


### PR DESCRIPTION
At the moment, Vale incorrectly reports the following error for any occurrence of "DM Multipath":

```
 61:1  error  Use 'Directory Manager' rather  RedHat.CaseSensitiveTerms 
              than 'DM'.
```
This is obviously problematic for Red Hat Enterprise Linux documentation that uses this term excessively. It is also potentially misleading because in this situation DM stands for "Device Mapper" so anyone following the advice would introduce a factual error in the documentation.