### PR TITLE
removed webview/Webview from spelling errors

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -57,8 +57,6 @@ symfony
 uber
 uri
 velero
-webview
-webviews
 woopra
 yaml
 zowe

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -367,8 +367,6 @@ Vert.x
 vsix
 WebAuthn
 WebSocket
-Webview
-Webviews
 Wildfly
 Woopra
 Wordpress

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -339,8 +339,6 @@ filters:
   - Vert.x
   - vsix
   - WebAuthn
-  - Webview
-  - Webviews
   - WebSocket
   - Wildfly
   - Woopra


### PR DESCRIPTION
Since both "webview" and "Webview" are valid spellings, I removed the entry from SpellingErrors