### PR TITLE
Recommend lower case for "Image Builder"

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -178,6 +178,7 @@ IA64
 IBM z Systems
 Ignite
 ignition config
+Image Builder
 Infiniband
 INSTALL_DIR
 installDir

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -106,6 +106,7 @@ IBM S/390
 IBM Z
 IdM CA renewal server
 IdM server and replicas
+image builder
 Ignition config
 inference engine
 InfiniBand

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -135,6 +135,7 @@ swap:
   IBM z Systems: IBM Z
   Ignite|Fuse Ignite: Fuse Online|Red Hat Fuse Online|Syndesis
   ignition config: Ignition config
+  Image Builder: image builder
   INSTALL_DIR|installDir: FUSE_HOME
   Iops|IOPs: IOPS
   Ip: IP


### PR DESCRIPTION
The official position of Red Hat is to spell "image builder" with lower case letters to distinguish it from official products that use capitalization. This applies to formal documentation as well as blog posts and other documents. As this presents a change to how we used to refer to it, having Vale report it would be a great help.