### PR TITLE
feat: don't report an error for 'APIs' (#489

### DIFF
--- a/.vale/fixtures/RedHat/Definitions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Definitions/testvalid.adoc
@@ -1,6 +1,8 @@
+// suppress inspection "IncorrectFormatting" for whole file
 ACPI
 AIX
 API
+APIs
 ARM
 ASCII
 ASP

--- a/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
@@ -1,3 +1,4 @@
+// suppress inspection "IncorrectFormatting" for whole file
 == camelCase term should not be flagged in headings
 3scale
 AGPLv

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -1,3 +1,4 @@
+// suppress inspection "IncorrectFormatting" for whole file
 a .NET application
 accessor
 adoc
@@ -8,12 +9,13 @@ Annobin
 Ansible
 Antora
 API
+APIs
 AssertJ
 autostart
 Autostart
 aws
 AWS
-Azure
+Microsoft Azure
 backfilling
 Backfilling
 backtrace
@@ -38,7 +40,7 @@ Bugzilla
 build config
 CentOS
 Ceph
-cephfs
+CephFS
 cgroup
 che
 Che
@@ -64,12 +66,15 @@ configure
 Containerfile
 Containerfiles
 Cookiecutter
+CPU
+CPUs
 CR
 CRD
 CRDs
 CRs
 CSVs
 Ctrl
+CVEs
 Cygmon
 DaemonSet
 Datadog
@@ -121,10 +126,13 @@ Fortran
 Funqy
 Gbps
 GCC
+GID
+GIDs
 Git
 GitHub
 GitLab
 Gluster
+GNUPro
 GraalVM
 Gradle
 Grafana
@@ -166,7 +174,6 @@ Journald
 Journaling
 Joyent
 JUnit
-jvm
 JVM
 Kafka
 kbd
@@ -240,6 +247,7 @@ Operator
 osd
 overridable
 PHP
+PIDs
 Podman
 PostgreSQL
 PowerShell
@@ -281,8 +289,10 @@ Rolfe
 Rollout
 Rollouts
 Rollup
+ROMs
 Roundtable
 Roundtables
+RPMs
 ruleset
 Runlevel
 Runlevels
@@ -346,6 +356,7 @@ Traceback
 Traefik
 Truststore
 Uber
+UIDs
 Uncomment
 Undercloud
 Uninstallation
@@ -358,7 +369,6 @@ Upsell
 Upselling
 URI
 URIs
-url
 URL
 URLs
 Valgrind

--- a/.vale/styles/RedHat/Definitions.yml
+++ b/.vale/styles/RedHat/Definitions.yml
@@ -10,6 +10,7 @@ first: '\b([A-Z]{3,5}s?)\b'
 second: '\(([A-Z]{3,5}s?)\)'
 # ... with the exception of these:
 exceptions:
+  - 'APIs?'
   - 'CPUs?'
   - 'CVEs?'
   - 'DVDs?'
@@ -23,11 +24,10 @@ exceptions:
   - 'URLs?'
   - ACPI
   - AIX
-  - API
   - ARM
   - ASCII
   - ASP
-  - AWS 
+  - AWS
   - BIND
   - BIOS
   - BMC

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -1,3 +1,4 @@
+#file: noinspection IncorrectFormatting
 ---
 extends: spelling
 level: warning
@@ -187,12 +188,14 @@ filters:
   - Containerfile
   - Containerfiles
   - Cookiecutter
+  - CPUs
   - CR
   - CRD
   - CRDs
   - CRs
   - CSVs
   - Ctrl
+  - CVEs
   - Cygmon
   - DaemonSet
   - Datadog
@@ -218,9 +221,11 @@ filters:
   - Fortran
   - Funqy
   - GCC
+  - GIDs
   - GitHub
   - GitLab
   - Gluster
+  - GNUPro
   - Gradle
   - Grayscale
   - GraalVM
@@ -292,6 +297,7 @@ filters:
   - OpenTracing
   - osd
   - PHP
+  - PIDs
   - Podman
   - PostgreSQL
   - PowerShell
@@ -309,6 +315,8 @@ filters:
   - RESTEasy
   - Rolfe
   - Rollup
+  - ROMs
+  - RPMs
   - Sakila
   - sbt
   - SCM
@@ -329,6 +337,7 @@ filters:
   - Toolset
   - Traefik
   - Uber
+  - UIDs
   - URI
   - URIs
   - url


### PR DESCRIPTION
* fixes #488
* fixes also other rules that were raising false positive alerts on words in the `Definitions/testvalid.adoc` file