### PR TITLE
chore: compatibility with Vale 2.24.1

### DIFF
--- a/.vale/styles/RedHat/Abbreviations.yml
+++ b/.vale/styles/RedHat/Abbreviations.yml
@@ -4,6 +4,6 @@ level: error
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/abbreviations/
 message: "Do not use periods in all-uppercase abbreviations such as '%s'."
 nonword: true
-source: "IBM - Periods with abbreviations, p. 5"
+# source: "IBM - Periods with abbreviations, p. 5"
 tokens:
   - '\b(?:[A-Z]\.){3,5}'

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -4,7 +4,7 @@ ignorecase: false
 level: error
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/casesensitiveterms/
 message: Use '%s' rather than '%s'.
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions"
 action:
   name: replace
 swap:

--- a/.vale/styles/RedHat/Conjunctions.yml
+++ b/.vale/styles/RedHat/Conjunctions.yml
@@ -4,7 +4,7 @@ level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/conjunctions/
 message: "Do not overuse beginning sentences with '%s'."
 scope: paragraph
-source: https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles/RedHat/Conjunctions.yml
+# source: https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles/RedHat/Conjunctions.yml
 action:
   name: remove
 tokens:

--- a/.vale/styles/RedHat/ConsciousLanguage.yml
+++ b/.vale/styles/RedHat/ConsciousLanguage.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/consciouslanguage/
 message: Use '%s' rather than '%s.'
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#conscious-language"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#conscious-language"
 action:
   name: replace
 swap:

--- a/.vale/styles/RedHat/Contractions.yml
+++ b/.vale/styles/RedHat/Contractions.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/contractions/
 message: "Avoid contractions. Use '%s' rather than '%s.'"
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#contractions"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#contractions"
 action:
   name: replace
 swap:

--- a/.vale/styles/RedHat/Definitions.yml
+++ b/.vale/styles/RedHat/Definitions.yml
@@ -4,7 +4,7 @@ ignorecase: false
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/definitions/
 message: "Define acronyms and abbreviations (such as '%s') on first occurrence if they're likely to be unfamiliar."
-source: "IBM - Abbreviations, p. 1"
+# source: "IBM - Abbreviations, p. 1"
 # Ensures that the existence of 'first' implies the existence of 'second'.
 first: '\b([A-Z]{3,5}s?)\b'
 second: '\(([A-Z]{3,5}s?)\)'

--- a/.vale/styles/RedHat/Ellipses.yml
+++ b/.vale/styles/RedHat/Ellipses.yml
@@ -4,7 +4,7 @@ level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/ellipses/
 message: "Avoid the ellipsis (...) except to indicate omitted words."
 nonword: true
-source: "IBM - Ellipses, p.49"
+# source: "IBM - Ellipses, p.49"
 action:
   name: remove
 tokens:

--- a/.vale/styles/RedHat/HeadingPunctuation.yml
+++ b/.vale/styles/RedHat/HeadingPunctuation.yml
@@ -5,7 +5,7 @@ link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference
 message: "Do not use end punctuation in headings."
 nonword: true
 scope: heading
-source: "IBM - Periods in headings and titles, p. 61"
+# source: "IBM - Periods in headings and titles, p. 61"
 action:
   name: edit
   params:

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -5,7 +5,7 @@ link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference
 match: $sentence
 message: "Use sentence-style capitalization in '%s'."
 scope: heading
-source: "IBM - Capitalization in headings and titles, p.16"
+# source: "IBM - Capitalization in headings and titles, p.16"
 indicators:
   - ":"
 exceptions:

--- a/.vale/styles/RedHat/OxfordComma.yml
+++ b/.vale/styles/RedHat/OxfordComma.yml
@@ -3,6 +3,6 @@ extends: existence
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/oxfordcomma/
 message: "Use the Oxford comma in '%s'."
-source: "IBM - Commas between clauses, p.45"
+# source: "IBM - Commas between clauses, p.45"
 tokens:
   - '(?:[^,]+,){1,}\s\w+\sand'

--- a/.vale/styles/RedHat/PascalCamelCase.yml
+++ b/.vale/styles/RedHat/PascalCamelCase.yml
@@ -5,7 +5,7 @@ level: suggestion
 scope: [list, sentence]
 link: https://redhat-documentation.github.io/asciidoc-markup-conventions
 message: "Consider wrapping this Pascal or Camel case term ('%s') in backticks."
-source: https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles/RedHat/PascalCamelCase.yml
+# source: https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles/RedHat/PascalCamelCase.yml
 tokens:
   #PascalCase
   - ([A-Z]+[a-z]+){2,}

--- a/.vale/styles/RedHat/PassiveVoice.yml
+++ b/.vale/styles/RedHat/PassiveVoice.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/passivevoice/
 message: "'%s' is passive voice. In general, use active voice. Consult the style guide for acceptable use of passive voice."
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#prerequisites; IBM - Voice, p.35"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#prerequisites; IBM - Voice, p.35"
 raw:
   - \b(am|are|were|being|is|been|was|be)\b\s*
 tokens:

--- a/.vale/styles/RedHat/ReleaseNotes.yml
+++ b/.vale/styles/RedHat/ReleaseNotes.yml
@@ -4,7 +4,7 @@ ignorecase: false
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/releasenotes/
 message: "For release notes, consider using '%s' rather than '%s'."
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#release-notes"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#release-notes"
 # swap maps tokens in form of bad: good
 swap:
   Now: With this update

--- a/.vale/styles/RedHat/SelfReferentialText.yml
+++ b/.vale/styles/RedHat/SelfReferentialText.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/selfreferentialtext/
 message: "Avoid using self-referential text such as '%s'."
-source: "IBM - Audience and medium, p. 22"
+# source: "IBM - Audience and medium, p. 22"
 tokens:
   - this topic
   - this module

--- a/.vale/styles/RedHat/SentenceLength.yml
+++ b/.vale/styles/RedHat/SentenceLength.yml
@@ -4,6 +4,6 @@ level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/
 message: "Try to keep sentences to an average of 32 words or fewer."
 scope: sentence
-source: "IBM - Conversational style"
+# source: "IBM - Conversational style"
 max: 32
 token: \b(\w+)\b

--- a/.vale/styles/RedHat/SimpleWords.yml
+++ b/.vale/styles/RedHat/SimpleWords.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/simplewords/
 message: "Use simple language. Consider using '%s' rather than '%s'."
-source: "IBM - Conversational style; http://www.plainlanguage.gov/howto/wordsuggestions/simplewords.cfm"
+# source: "IBM - Conversational style; http://www.plainlanguage.gov/howto/wordsuggestions/simplewords.cfm"
 swap:
   "approximate(?:ly)?": about
   "objective(?! C?)": aim|goal

--- a/.vale/styles/RedHat/Slash.yml
+++ b/.vale/styles/RedHat/Slash.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/slash/
 message: "Use either 'or' or 'and' in '%s'"
-source: "IBM - Slashes, p. 68"
+# source: "IBM - Slashes, p. 68"
 tokens:
   - '(?<!/)\w+/\w+'
 exceptions:

--- a/.vale/styles/RedHat/Spacing.yml
+++ b/.vale/styles/RedHat/Spacing.yml
@@ -4,7 +4,7 @@ level: error
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/spacing/
 message: "Keep one space between words in '%s'."
 nonword: true
-source: https://docs.microsoft.com/en-us/style-guide/punctuation/periods
+# source: https://docs.microsoft.com/en-us/style-guide/punctuation/periods
 tokens:
   - "[a-z][.?!] {2,}[A-Z]"
   - "[a-z][.?!][A-Z]"

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -4,7 +4,7 @@ extends: spelling
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/spelling/
 message: "Use correct American English spelling. Did you really mean '%s'?"
-source: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/spelling/
+# source: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/spelling/
 # A "filter" is a case-sensitive regular expression specifying words to ignore during spell checking.
 # Spelling rule applies to individual words
 filters:

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: error
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termserrors/
 message: "Use '%s' rather than '%s'."
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
 action:
   name: replace
 # swap maps tokens in form of bad: good

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -4,7 +4,7 @@ ignorecase: false
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termssuggestions/
 message: "Depending on the context, consider using '%s' rather than '%s'."
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
 action:
   name: replace
 swap:

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termswarnings/
 message: "Consider using '%s' rather than '%s' unless updating existing content that uses the term."
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
 action:
   name: replace
 swap:

--- a/.vale/styles/RedHat/Usage.yml
+++ b/.vale/styles/RedHat/Usage.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/usage/
 message: "Verify your use of '%s' with the word usage guidelines."
-source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
+# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
 tokens:
   - "pop-up (?:help|menu)"
   - "redbook(:s)?"

--- a/.vale/styles/RedHat/UserReplacedValues.yml
+++ b/.vale/styles/RedHat/UserReplacedValues.yml
@@ -1,5 +1,5 @@
 ---
-source: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/userreplacedvalues/
+# source: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/userreplacedvalues/
 extends: substitution
 message: '%s, rather than %s'
 level: suggestion


### PR DESCRIPTION
* With Vale v2.24.1, unknown keys are now an error, see: https://github.com/errata-ai/vale/releases/tag/v2.24.1
* The `source` key is obsolete

Fixes errors:

```
+ vale modules/administration-guide/partials/proc_selecting-an-open-vsx-registry-instance.adoc modules/end-user-guide/partials/proc_setting-up-che-editor-yaml.adoc
E201 Invalid value [/projects/.vale/styles/RedHat/Abbreviations.yml:1:1]:

   1* ---
   2  extends: existence
   3  level: error

1 error(s) decoding:

* '' has invalid keys: source
```

See: https://github.com/eclipse-che/che-docs/actions/runs/4628864466/jobs/8189824489