### PR TITLE
Adds VMware as pascal exception and allows "machine"

### DIFF
--- a/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
@@ -170,6 +170,7 @@ vCPUs
 vDisk
 vHost
 VMs
+VMware
 vSphere
 WebAuthn
 WebSocket

--- a/.vale/fixtures/RedHat/Usage/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Usage/testinvalid.adoc
@@ -86,7 +86,6 @@ lite
 localize
 look and feel
 look-and-feel
-machine
 master and slave
 migrate
 native

--- a/.vale/fixtures/RedHat/Usage/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Usage/testvalid.adoc
@@ -1,4 +1,2 @@
 pop-up
-virtual machine
-machine learning
-Podman machine
+machine

--- a/.vale/styles/RedHat/PascalCamelCase.yml
+++ b/.vale/styles/RedHat/PascalCamelCase.yml
@@ -167,6 +167,7 @@ exceptions:
   - USBGuard
   - vDisk
   - vHost
+  - VMware
   - vSphere
   - WebAuthn
   - WebSocket

--- a/.vale/styles/RedHat/Usage.yml
+++ b/.vale/styles/RedHat/Usage.yml
@@ -93,7 +93,6 @@ tokens:
   - localize
   - look and feel
   - look-and-feel
-  - "(?<!virtual |Podman )machine(?! learning)"
   - master and slave
   - migrate
   - native


### PR DESCRIPTION
Per discussion in https://github.com/openshift/openshift-docs/pull/60604#issue-1727661831

- VMware is an allowed word, but was tripping the pascal case rule. Added an exception.
- ISG says not to use "machine" but we use it (validly) all the time, and I don't think that's specifically just OCP docs. Removed it from the usage list.