### PR TITLE
add rule for descriptive link text

### DIFF
--- a/.vale/fixtures/AsciiDoc/ImageContainsAltText/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ImageContainsAltText/.vale.ini
@@ -1,4 +1,4 @@
-; Vale configuration file to test the `XrefContainsAnchorID` rule
+; Vale configuration file to test the `ImageContainsAltText` rule
 StylesPath = ../../../styles
 MinAlertLevel = suggestion
 [*.adoc]

--- a/.vale/fixtures/AsciiDoc/LinkContainsLinkText/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/LinkContainsLinkText/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `LinkContainsLinkText` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+AsciiDoc.LinkContainsLinkText = YES

--- a/.vale/fixtures/AsciiDoc/LinkContainsLinkText/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/LinkContainsLinkText/testinvalid.adoc
@@ -1,0 +1,14 @@
+//vale-fixture
+link:https://docs.aws.amazon.com/[] 
+
+link:https://docs.aws.amazon.com/[Click here]
+
+link:https://docs.aws.amazon.com/[click here]
+
+link:https://docs.aws.amazon.com/[here]
+
+link:https://docs.aws.amazon.com/[Here]
+
+link:https://docs.aws.amazon.com/[this]
+
+link:https://docs.aws.amazon.com/[This]

--- a/.vale/fixtures/AsciiDoc/LinkContainsLinkText/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/LinkContainsLinkText/testvalid.adoc
@@ -1,0 +1,2 @@
+//Correct usage of link text in links
+link:https://docs.aws.amazon.com/[AWS documentation] 

--- a/.vale/styles/AsciiDoc/LinkContainsLinkText.yml
+++ b/.vale/styles/AsciiDoc/LinkContainsLinkText.yml
@@ -1,0 +1,10 @@
+---
+extends: existence
+scope: raw
+level: warning
+ignorecase: true
+nonword: true
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cloud-services-links-hypertext
+message: "Link is missing descriptive link text for accessibility."
+raw:
+  - 'link:.*(\[\]|\[click here\]|\[here\]|\[this\])'

--- a/modules/reference-guide/nav.adoc
+++ b/modules/reference-guide/nav.adoc
@@ -9,6 +9,8 @@
 * xref:ellipses.adoc[]
 * xref:headingpunctuation.adoc[]
 * xref:headings.adoc[]
+//* xref:images.adoc[]
+//* xref:links.adoc[]
 * xref:oxfordcomma.adoc[]
 * xref:pascalcamelcase.adoc[]
 * xref:passivevoice.adoc[]

--- a/modules/reference-guide/pages/images.adoc
+++ b/modules/reference-guide/pages/images.adoc
@@ -1,0 +1,10 @@
+:navtitle: Images
+:keywords: reference, rule, Images
+
+= Images
+
+Use text equivalents for every diagram, image, or other non-text element.
+
+.Additional resources
+
+* link:{ssg-url}?topic=grammar-capitalization#cloud-services-images[{ssg} - Images]

--- a/modules/reference-guide/pages/links.adoc
+++ b/modules/reference-guide/pages/links.adoc
@@ -1,0 +1,10 @@
+:navtitle: Links
+:keywords: reference, rule, Links
+
+= Links
+
+Always include link text for URLs. The link text must be descriptive.
+
+.Additional resources
+
+* link:{ssg-url}?topic=grammar-capitalization#cloud-services-links-hypertext[{ssg} - Links and hypertext]


### PR DESCRIPTION
Based on https://redhat-documentation.github.io/supplementary-style-guide/?topic=grammar-capitalization#cloud-services-links-hypertext

I added a rule that I hope flags empty link text and link text that only contains "click here" in a case insensitive way.

I also added pages for link text and images.