### PR TITLE
Accomodating `==` format headings for additional resources rule

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID/testinvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID/testinvalid.adoc
@@ -1,2 +1,8 @@
 //vale-fixture
 .Additional resources
+
+//vale-fixture
+== Additional resources
+
+//vale-fixture
+=== Additional resources

--- a/.vale/fixtures/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID/testvalid.adoc
@@ -1,2 +1,8 @@
 [role="_additional-resources"]
 .Additional resources
+
+[role="_additional-resources"]
+== Additional resources
+
+[role="_additional-resources"]
+=== Additional resources

--- a/.vale/styles/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID.yml
@@ -2,7 +2,9 @@
 extends: existence
 scope: raw
 level: suggestion
+nonword: true
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#additional-resources-sections
 message: "Additional resources heading is missing the \"_additional-resources\" role attribute declaration"
-raw:
+tokens:
   - '(?<!\/\/)(?<!\[role="_additional-resources"\]\n)\.Additional resources'
+  - '(?<!\/\/)(?<!\[role="_additional-resources"\]\n)^=+ Additional resources'  


### PR DESCRIPTION
See here: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#additional-resources-sections

This updates the Additional resources rule for assemblies to ensure it catches `== Additional resources` and `.Additional resources`. Dot formatting can be used in modules or assemblies. == format is used in assemblies only.