### PR TITLE
Add new Vale rule to catch instances of "Red Hat Java"

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -371,6 +371,8 @@ Red Boot
 Red Hat Broker
 Red Hat Console
 Red Hat Interconnect
+Red Hat Java
+Red Hat java
 Red Hat JBoss Data Grid
 Red Hat JBoss EAP
 Red Hat Network Satellite server

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -222,6 +222,8 @@ Red Hat Data Grid
 Red Hat Directory Server
 Red Hat Enterprise Linux host
 Red Hat Fuse Online
+Red Hat OpenJDK
+Red Hat build of OpenJDK
 Red Hat JBoss BPM Suite
 Red Hat JBoss BRMS
 Red Hat JBoss Enterprise Application Platform

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -228,6 +228,7 @@ swap:
   Red Hat JBoss Data Grid|JDG: Red Hat Data Grid
   Red Hat JBoss EAP: Red Hat JBoss Enterprise Application Platform
   Red Hat Network Satellite server: Red Hat Network Satellite Server
+  Red Hat Java|Red Hat java: Red Hat build of OpenJDK|Red Hat OpenJDK
   Red Hat Proxy: Red Hat Network Proxy Server
   Red Hat Satellite Capsule server: Red Hat Satellite Capsule Server
   Red Hat Satellite server: Red Hat Satellite Server


### PR DESCRIPTION
Enhances vale-at-red-hat rules as per recent CCS communication requesting that all instances of `Red Hat Java` are replaced with `Red Hat OpenJDK` or the full product name `Red Hat build of OpenJDK`.

Extract: 
"...always mention Red distribution of JDK as Red Hat OpenJDK.
Never use Red Hat Java in any content"

_**Note:** Not sure if the Red Hat `CaseSensitiveTerms.yml` rule is the right place for this but as per other similar Red Hat product name rules live here... I think these fall under a rule for product names as per @abhatt-rh's enhancement GH issue #530._ 