### PR TITLE
Follow on rule enhancement to #578

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -371,8 +371,6 @@ Red Boot
 Red Hat Broker
 Red Hat Console
 Red Hat Interconnect
-Red Hat Java
-Red Hat java
 Red Hat JBoss Data Grid
 Red Hat JBoss EAP
 Red Hat Network Satellite server

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -222,7 +222,6 @@ Red Hat Data Grid
 Red Hat Directory Server
 Red Hat Enterprise Linux host
 Red Hat Fuse Online
-Red Hat OpenJDK
 Red Hat build of OpenJDK
 Red Hat JBoss BPM Suite
 Red Hat JBoss BRMS

--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -289,10 +289,15 @@ pseudoops
 pull-down
 re-occur
 recognise
+Red Hat Java
+Red Hat java
+Red Hat Open Java Development Kit
+Red Hat OpenJDK
 regex
 remote-access
 remote-access server
 reoccur
+RHOJDK
 right double-click
 right now
 right-hand

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -167,6 +167,7 @@ Internet email address
 IP address
 issue
 IT
+Java
 kernel oops
 kernel-space
 knowledge base
@@ -220,6 +221,7 @@ onsite
 opcode
 open
 open source
+OpenJDK
 OpenShift
 override
 parent process
@@ -255,6 +257,7 @@ remove
 required
 retry
 right
+Red Hat build of OpenJDK
 roll back
 rollback
 root directory

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -228,7 +228,6 @@ swap:
   Red Hat JBoss Data Grid|JDG: Red Hat Data Grid
   Red Hat JBoss EAP: Red Hat JBoss Enterprise Application Platform
   Red Hat Network Satellite server: Red Hat Network Satellite Server
-  Red Hat Java|Red Hat java: Red Hat build of OpenJDK|Red Hat OpenJDK
   Red Hat Proxy: Red Hat Network Proxy Server
   Red Hat Satellite Capsule server: Red Hat Satellite Capsule Server
   Red Hat Satellite server: Red Hat Satellite Server

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -244,6 +244,8 @@ swap:
   pseudo ops|pseudoops: pseudo-ops
   pull-down: pulldown
   recognise: recognize
+  Red Hat OpenJDK|RHOJDK|Red Hat Open Java Development Kit: Red Hat build of OpenJDK
+  Red Hat Java: Red Hat build of OpenJDK
   regex: regular expression
   remote-access server: remote access server
   remote-access: remote access


### PR DESCRIPTION
Further enhances the previously merged rule https://github.com/redhat-documentation/vale-at-red-hat/pull/578 following further Red Hat SME discussion about the guideline.

See also related Red Hat style PR [362](https://github.com/redhat-documentation/supplementary-style-guide/pull/362).