### PR TITLE
Clean up warnings and suggestions rule

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -1,46 +1,29 @@
-64-bit x86
-and so on
 as
-bare metal
-bare-metal
-between
-bps
-Bps
-cd
-CD
-channel
-client side
-client-side
-code
-crash
-functionality
-Hammer
+bare metal clusters
+bare metal compute
+bare metal configuration
+bare metal control
+bare metal environment
+bare metal equipment
+bare metal event
+bare metal hardware
+bare metal host
+bare metal infrastructure
+bare metal installation
+bare metal installer
+bare metal machine
+bare metal media
+bare metal node
+bare metal provisioning
+bare metal server
+bare metal worker
 information on
-input
-jar
 Navigate
 navigate
-recommend
 refer to
-roll out
-roll-out
-rollout
-Router
 segfault
 shell
 Start using this.
-tar
-this clause which is nonrestrictive
-this clause, that is restrictive
-through
-thru
-type
-unjar
-user space
-user-space
-userspace
+This clause which is nonrestrictive
+This clause, that is restrictive
 via
-x64
-x86-64
-x86_64
-zip

--- a/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
@@ -1,5 +1,3 @@
-AMD64
-archive
 bare-metal clusters
 bare-metal compute
 bare-metal configuration
@@ -18,19 +16,15 @@ bare-metal node
 bare-metal provisioning
 bare-metal server
 bare-metal worker
-compress
-enter
-functions
+by
+by using
+from
 information about
-JAR
-JAR file
-repository
-see
+on
+see this section
 segmentation fault
 shell prompt
 shell script
-Start by using this.
-such as
 this clause that is restrictive
 this clause, which is nonrestrictive
-write
+through

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -1,5 +1,4 @@
 BIOS
-CRUD
 entitlement
 he
 host name

--- a/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
@@ -1,19 +1,18 @@
+accurate
 by
 by using
+can
+firmware
 from
-host
 hostname
-I/O
 in-house
 might
-name
 on
 on-premise
 on-site
 plugin
 repository
 subscription
-through
 tool
 tools
 you

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -4,38 +4,18 @@ ignorecase: false
 level: suggestion
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termssuggestions/
 message: "Depending on the context, consider using '%s' rather than '%s'."
-# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
 action:
   name: replace
 swap:
-  "(?<!,) which": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
-  "(?<!by) using": by using|that uses
+  "(?<!,) which": ", which| that"
+  "(?<!by) using": " by using| that uses"
   "(?<!such )as": because|while
-  ", that": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
-  "[Bb]are metal|[Bb]are-metal(?! clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal (noun)|bare-metal (adjective)
+  ", that": ", which| that"
+  "[Bb]are metal(?= clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare-metal
+  "[Bb]are-metal(?! clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal
+  "[Nn]avigate": click|select|browse|go to
   "shell(?! prompt| script)": shell prompt
-  and so on: "appropriate descriptive wording, unless you list a clear sequence of elements"
-  between: " - ' to indicate a 'range of numbers"
-  Bps|bps: Bps (bytes per second)|bps (bits per second)
-  CD|cd: cd (change directory command)|CD (compact disc)
-  channel: repository
-  client side|client-side: client-side (adjective)| client side (noun)
-  code: write
-  crash: fail|lock up|stop|stop responding
-  functionality: functions # IBM
-  Hammer|x86_64|x86-64|x64|64-bit x86: AMD64
   information on: information about
-  input|type: enter (followed by the text to enter in monospace) # https://redhat-documentation.github.io/supplementary-style-guide/#text-entry
-  jar: compress|archive (verb)
-  Navigate|navigate: '"click", "select", "browse", or "go to"'
-  recommend: direct users to take the recommended action
   refer to: see
-  roll-out|roll out|rollout: roll out (verb)|rollout (noun)
-  Router: AMQ Interconnect
   segfault: segmentation fault
-  tar: compress|archive
-  thru|through: "' - ' (range)|by using|finished|completed"
-  unjar: extract (verb)
-  user space|userspace|user-space: user space (noun)| user-space (modifier)
   via: through|by|from|on|by using
-  zip: compress

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -4,15 +4,13 @@ ignorecase: true
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termswarnings/
 message: "Consider using '%s' rather than '%s' unless updating existing content that uses the term."
-# source: "https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions; IBM - Appendix C. Word usage, p. 300"
 action:
   name: replace
 swap:
-  CRUD: create, retrieve, update, and delete (CRUD)
-  "I(?!/O)": you
+  'I(?!/O)': you
   he|she: you
   host name: hostname
-  may: might (for possiblity)|can (for ability)
+  may: might|can
   on-premises|on-prem|on premise: on-premise|on-site|in-house
   entitlement: repository|subscription
   plug-in: plugin


### PR DESCRIPTION
1. Corrects quick replace text
2. Removes CRUD from Warning rule since "CRUD" is caught by the Abbreviations rule
3. Removes a lot of Suggestion terms because these are now in the reworked Usage rule https://github.com/redhat-documentation/vale-at-red-hat/pull/585

This PR is a more manageable piece of this larger PR: https://github.com/redhat-documentation/vale-at-red-hat/pull/539