### PR TITLE
Adding a "do not use" terms rule

### DIFF
--- a/.vale/fixtures/RedHat/DoNotUseTerms/.vale.ini
+++ b/.vale/fixtures/RedHat/DoNotUseTerms/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `DoNotUseTerms` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.DoNotUseTerms = YES

--- a/.vale/fixtures/RedHat/DoNotUseTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/DoNotUseTerms/testinvalid.adoc
@@ -1,0 +1,28 @@
+ACK
+basically
+congratulations
+daughterboard
+destroy
+devs
+domestic
+foo
+foreign
+fubar
+future-proof
+geo
+geography
+kerberize
+kerberized
+native interface
+out of the box
+out-of-the-box
+overhead
+please
+quiescent
+resides
+respective
+respectively
+time-tested
+we
+debuggable
+and/or

--- a/.vale/fixtures/RedHat/DoNotUseTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/DoNotUseTerms/testvalid.adoc
@@ -1,0 +1,2 @@
+hash sign
+ACK flag

--- a/.vale/styles/RedHat/DoNotUseTerms.yml
+++ b/.vale/styles/RedHat/DoNotUseTerms.yml
@@ -1,0 +1,32 @@
+---
+extends: substitution
+ignorecase: true
+level: error
+link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/donotuseterms/
+message: "%s"
+swap:
+  # Start each error message with "Do not use ..."
+  # Error messages must be single quoted.
+  'ACK(?! flag)': 'Do not use "ACK" as acronym for "acknowledgement". When writing about the acknowledgement flag ("ACK flag") in a TCP packet, use "ACK flag".'
+  'domestic|foreign': 'Do not use "domestic" and "foreign" to differentiate geographic locations.'
+  'future-proof': Do not use "future-proof" in a statement about the benefits, characteristics, or performance of a Red Hat product or service.'
+  'geo|geography': 'Do not use "geo" or "geography" to mean geographical area in customer-facing content. Write, for example, "This version is available worldwide."'
+  'out of the box|out-of-the-box': 'Do not use "out of the box" or "out-of-the-box". Use text that is suitable for the context and the noun to which this adjective applies.'
+  and/or: 'Do not use "and/or". Depending on the context, use one of the following constructions: a and b, a or b, or a, b, or both.'
+  basically: 'Do not use "basically". "Basically" is another term for "in principle" or "fundamentally".'
+  congratulations: 'Do not use "congratulations" in technical information."'
+  daughterboard: 'Do not use "daughterboard". Use the specific name or function of the plug-in adapter that you are referring to.'
+  debuggable: 'Do not use "debuggable". Rephrase the sentence to use the verb or noun debug. For example, change rebuild the debuggable version to rebuild the version that can be debugged.'
+  destroy: 'Do not use "destroy" to refer to the removal of an object from a database. Write specifically what happens to the object, such as deleting it from the database.'
+  devs?: 'Do not use "dev" as a synonym for development or developer.'
+  foo: 'Do not use "foo". This term is technical jargon in code and as shorthand for fubar, an acronym of profanity in code.'
+  fubar: 'Do not use "fubar". This term is an acronym of a profanity that is sometimes used by developers in code.'
+  kerberize|kerberized: 'Do not use "kerberize" to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled", or rewrite the sentence.'
+  native interface: 'Do not use "native interface" to refer to the command line interface for the JBoss EAP management tool.'
+  overhead: 'Do not use "overhead". Use terminology that is more specific. For example, write "running large queries can increase processor usage".'
+  please: 'Do not use "please" in technical documentation.'
+  quiescent: 'Do not use "quiescent". If a system is, or needs to be inactive, write "inactive". If a system is, or needs to be safe, write "safe".'
+  resides: 'Do not use "resides" if a simpler verb is possible.'
+  respective|respectively: 'Do not use "respective" or "respectively". Rewrite to avoid using these words.'
+  time-tested: 'Do not use "time-tested". Time-tested implies a claim of suitability or reliability.'
+  we: 'Do not use "we" to refer to Red Hat or to refer collectively to both the authors and the audience.'


### PR DESCRIPTION
Adding a "do not use" terms rule. Instead of suggesting text replacement, the swap field is used to provide inline context to the user regarding the specific term.

```terminal
$ vale .

 testinvalid.adoc
 1:1  suggestion  Do not use "please". Terms of   RedHat.DoNotUseTerms 
                  politeness are superfluous,                          
                  convey the wrong tone for                            
                  technical material, and are                          
                  not regarded the same way in                         
                  all cultures.                                        
```

![image](https://github.com/redhat-documentation/vale-at-red-hat/assets/74046732/c1eb7de6-b184-4855-82b6-96b0c8cbe845)

