### PR TITLE
Add fixes to reduce spelling rule false positives

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testinvalid.adoc
@@ -12,11 +12,9 @@ ctrl
 Daemonset
 dns
 dotnet
-endevor
 gluster
 Graal VM
 graal vm
-gradle
 gui
 homebrew
 Ide
@@ -54,7 +52,6 @@ scm
 svg
 symfony
 uber
-uri
 velero
 VMWare
 woopra

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -24,6 +24,7 @@ Backfilling
 backported
 backtrace
 Backtrace
+bcrypt
 Bierner
 bindable
 Bindable
@@ -131,6 +132,8 @@ Fernflower
 firewalld
 Flathub
 Flatpak
+Fluentd
+Flyway
 Fortran
 Funqy
 Gbps
@@ -140,9 +143,13 @@ GIDs
 Git
 GitHub
 GitLab
+Gradle
 Gluster
 GNUPro
 GraalVM
+GraphQL
+Graylog
+gRPC
 Gradle
 Grafana
 GraphQL
@@ -175,6 +182,7 @@ IntelliJ
 IPsec
 IPv
 ISeries
+Istio
 ISVs
 Itanium
 Item
@@ -193,6 +201,7 @@ Joyent
 JUnit
 JVM
 Kafka
+Kubernetes
 kbd
 Keycloak
 Keylime
@@ -217,7 +226,9 @@ libvirt
 Libvirt
 Licensor
 Liveness
+Logstash
 Lombok
+Liquibase
 Loopback
 Makefile
 Matrixes

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -23,13 +23,18 @@ filters:
   - "[bB]reakpoints"
   - "[cC]he"
   - "[cC]lassloading"
+  - "[cC]lasspath"
   - "[cC]olocate"
   - "[cC]onfig"
+  - "[cC]ustomizer"
+  - "[dD]atasource"
   - "[dD]eclaratively"
   - "[dD]ecompiler"
   - "[dD]eserialization"
+  - "[dD]eserialized"
   - "[dD]esynchronize"
   - "[dD]esynchronized"
+  - "[dD]ev"
   - "[dD]ev[wW]orkspace"
   - "[dD]evfile"
   - "[dD]evfiles"
@@ -40,8 +45,10 @@ filters:
   - "[Ff]actory"
   - "[fF]ailback"
   - "[fF]ailover"
+  - "[fF]indability"
   - "[gG]bps"
   - "[gG]it"
+  - "[gG]radle"
   - "[gG]rafana"
   - "[hH]ardcoding"
   - "[hH]eatmap"
@@ -58,10 +65,12 @@ filters:
   - "[kK]eyrings"
   - "[lL]ibvirt"
   - "[lL]icensor"
+  - "[lL]iquibase"
   - "[lL]iveness"
   - "[lL]oopback"
   - "[mM]atrixes"
   - "[mM]ebibytes"
+  - "[mM]etamodel"
   - "[mM]iddleware"
   - "[mM]illicores"
   - "[mM]ixin"
@@ -82,6 +91,7 @@ filters:
   - "[pP]reconfigured"
   - "[pP]regenerated"
   - "[pP]ulldown"
+  - "[pP]reconfigured"
   - "[pP]repend"
   - "[pP]repended"
   - "[pP]roductize"
@@ -108,13 +118,16 @@ filters:
   - "[rR]untime"
   - "[rR]untimes"
   - "[sS]crollbar"
+  - "[sS]earchability"
   - "[sS]erializer"
   - "[sS]erialization"
   - "[sS]erializable"
   - "[sS]erverless"
   - "[sS]ervlet"
+  - "[sS]etter"
   - "[sS]harding"
   - "[sS]ysctl"
+  - "[sS]yslog"
   - "[Ss]u"
   - "[sS]ubcommand"
   - "[sS]ubcommands"
@@ -171,6 +184,7 @@ filters:
   - BOM
   - Bonjour
   - Bouncy Castle
+  - bcrypt
   - btn
   - Btrfs
   - Bugzilla
@@ -183,7 +197,6 @@ filters:
   - Ciphertext
   - Civetweb
   - classloader
-  - classpath
   - Cloudbursting
   - Cloudwashing
   - CodeReady
@@ -229,6 +242,8 @@ filters:
   - firewalld
   - Flathub
   - Flatpak
+  - Fluentd
+  - Flyway
   - Fortran
   - Funqy
   - GCC
@@ -238,10 +253,11 @@ filters:
   - Gluster
   - GNUPro
   - GraalVM
-  - Gradle
   - GraphQL
-  - greenboot
   - Grayscale
+  - Graylog
+  - greenboot
+  - gRPC
   - GTIDs?
   - GUI
   - Hashicorp
@@ -261,6 +277,7 @@ filters:
   - IntelliJ
   - IPsec
   - ISeries
+  - Istio
   - IPPool
   - IPsec
   - IPv
@@ -288,13 +305,16 @@ filters:
   - Kompose
   - kubelet
   - Kubespray
+  - Kubernetes
   - Kylin
   - Laravel
   - LGPLv
   - librados
   - librbd
   - libOSMesa
+  - Logstash
   - Lombok
+  - Liquibase
   - Makefile
   - Mattermost
   - Maven
@@ -354,8 +374,8 @@ filters:
   - Redis
   - Redistributions
   - relaxngDatatype
-  - RESTEasy
   - Restic
+  - RESTEasy
   - Rolfe
   - Rollup
   - ROMs
@@ -400,6 +420,7 @@ filters:
   - vSphere
   - WebAuthn
   - Webpack
+  - WebView
   - WebSocket
   - Wildfly
   - Woopra


### PR DESCRIPTION
Fixes:

- False positive spelling warnings on Java-related software services/components/products/functions and some acceptable widely used programmatic terms encountered when running vale on Red Hat build of Quarkus docs.
- Removed some duplicate entries in spelling yml.

_Related heading rule enhancements to follow after this is merged._