### PR TITLE
Fix false positive churn flagged by the Headings and CaseSenstive rules

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -166,6 +166,7 @@ Graalvm
 graalVM
 green boots
 Greenboot
+GRPC
 Grub
 Gtk
 gtk
@@ -201,6 +202,7 @@ IPV6
 Ipv6
 iSeries
 iso
+Istio Service Mesh
 Itanium2
 jar file
 jbang

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -96,6 +96,7 @@ GNU
 GPL
 GraalVM
 greenboot
+gRPC
 GRUB
 GTK+
 GUI
@@ -111,6 +112,7 @@ IBM Z
 IdM CA renewal server
 IdM server and replicas
 Ignition config
+Istio service mesh
 image builder
 inference engine
 InfiniBand

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -36,3 +36,11 @@
 == Using a proxy requiring custom Certificate Authorities (CA)
 == JBang
 == OpenRewrite something
+== About Fluentd and Flyway
+== About Graylog and Istio
+== Installing JBoss Log Manager
+== Troubleshooting with JBoss Logging
+== Uninstalling Logstash
+== About WebView
+== Problems with gRPC and xDS
+

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -125,6 +125,7 @@ swap:
   Gnu|gnu: GNU
   Gpl|gpl: GPL
   Graalvm|graalVM: GraalVM
+  grpc|GRPC: gRPC
   Greenboot|green boots: greenboot
   Grub: GRUB
   GTK|Gtk|gtk: GTK+
@@ -138,6 +139,7 @@ swap:
   Ignite|Fuse Ignite: Fuse Online|Red Hat Fuse Online|Syndesis
   ignition config: Ignition config
   Image Builder: image builder
+  Istio Service Mesh : Istio service mesh
   INSTALL_DIR|installDir: FUSE_HOME
   Iops|IOPs: IOPS
   Ip: IP

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -79,6 +79,8 @@ exceptions:
   - Flathub
   - Flatpak
   - Flatpak Builder
+  - Fluentd
+  - Flyway
   - Fortran
   - Funqy
   - GCC
@@ -93,6 +95,7 @@ exceptions:
   - GraalVM
   - Gradle
   - GraphQL
+  - Graylog
   - Grayscale
   - GTK
   - HTTP
@@ -114,9 +117,12 @@ exceptions:
   - Infinispan
   - Intelephense
   - IntelliJ
+  - Istio
   - Itanium
   - JAR file
   - JBang
+  - JBoss Log Manager
+  - JBoss Logging
   - JUnit
   - JVM
   - Jakarta
@@ -136,6 +142,7 @@ exceptions:
   - Kubespray
   - Kylin
   - Laravel
+  - Logstash
   - Lombok
   - Makefile
   - Mandrel
@@ -226,6 +233,7 @@ exceptions:
   - WebSocket
   - Webview
   - Webviews
+  - WebView
   - Wildfly
   - Window Maker
   - Windows
@@ -238,10 +246,12 @@ exceptions:
   - Zowe
   - cgroup
   - eServer
+  - gRPC
   - mutual TLS
   - mTLS
   - qeth
   - startx
   - vNIC
   - vNUMA
+  - xDS
   - xterm


### PR DESCRIPTION
This PR reduces false positives that come up regularly in Quarkus doc content.
