### PR TITLE
Add OpenTelemetry to the Pascal rule exceptions

### DIFF
--- a/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
@@ -121,6 +121,7 @@ OpenShift
 OpenSSH
 OpenSSL
 OpenStack
+OpenTelemetry
 OpenTracing
 OperatorHub
 OpEx

--- a/.vale/styles/RedHat/PascalCamelCase.yml
+++ b/.vale/styles/RedHat/PascalCamelCase.yml
@@ -126,6 +126,7 @@ exceptions:
   - OpenSSH
   - OpenSSL
   - OpenStack
+  - OpenTelemetry
   - OpenTracing
   - OperatorHub
   - OpEx


### PR DESCRIPTION
To reduce Vale noise. 

[OpenTelemetry](https://opentelemetry.io/) is the name of a collection of APIs, SDKs, and tools, and is becoming more popular in Runtimes doc content.

