### PR TITLE
Do not suggest to replace "laptop" with "notebook"

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -207,7 +207,6 @@ irrecoverable
 keep in mind
 kernelspace
 labour
-laptop
 large page
 launch
 learnt

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -170,6 +170,7 @@ IT
 kernel oops
 kernel-space
 knowledge base
+laptop
 left
 left mouse button
 live-only

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -181,7 +181,6 @@ swap:
   keep in mind: remember
   kernelspace: kernel-space
   labour: labor
-  laptop: notebook
   large page|super page: huge page
   launch: start|open
   learnt: learned


### PR DESCRIPTION
The current version of the IBM Style Guide does not prohibit the use of the word "laptop" in any way and recommends it to refer to mobile computer that is not a handheld device. On the contrary, the IBM Style Guide recommends to use the word "notebook" to refer only to an interface element that resembles a physical notebook with pages and tabs.

I am therefore proposing to remove this rule as it goes against what the style guide recommends.