### PR TITLE
Do not report 'as well as per something'

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -18,6 +18,7 @@ as
 as expected
 as in
 as needed
+as well as per recipient
 Assisted Installer
 attention notice
 auto-detect

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -18,6 +18,7 @@ swap:
   "[bB]asic [aA]uth": Basic HTTP authentication (first instance)|Basic authentication
   "a lot(?: of)?": many|much
   "AI": Assisted Installer
+  "(?<!as well )as per": according to|as|as in
   "backward(?:-)?compatible": compatible with earlier versions
   "bottle neck|bottle-neck": bottleneck
   "bottom(?:-)?left": lower left|lower-left
@@ -55,7 +56,6 @@ swap:
   analyse: analyze
   and/or: a or b|a, b, or both
   as long as: if|provided that
-  as per: according to|as|as in
   autodetect: auto-detect
   back-level: earlier|previous|not at the latest level
   bi-monthly: bimonthly


### PR DESCRIPTION
The current implementation of `RedHat.TermsErrors` causes `vale` to report the following error for sentences like "you can configure meta options per alert agent as well as per recipient":

```
 15:56   error       Use 'according to', 'as', or    RedHat.TermsErrors      
                     'as in' rather than 'as per'.
```

While "as well as" on its own is not recommended by the IBM Style Guide and gets reported by `RedHat.Usage`, the above error is out of place and the suggested wording is confusing.