### PR TITLE
Update hard wrapped rule to accomodate sentence clauses

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/HardWrappedLines/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/HardWrappedLines/testvalid.adoc
@@ -92,3 +92,4 @@ image::product-workflow-overview.png[High-level {product-title} flow]
 
 include::modules/a-rather-very-very-long-very-log-very-long-indeed-so-long-file.adoc[]
 
+Hard drive:: Permanent storage for operating system and/or user files that are used on a daily basis

--- a/.vale/styles/OpenShiftAsciiDoc/HardWrappedLines.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/HardWrappedLines.yml
@@ -16,7 +16,7 @@ script: |
   list_regex := "^(\\.|\\*|-).*$"
   hard_wrap_80_regex := "^.{65,80}$"
   hard_wrap_100_regex := "^.{75,100}$"
-  asciidoc_markup := "^(.*\\[.*\\]|\\/\\/.*|=+.*|<(\\.|\\d+)>.*|>|#+.*|\\..+|\\|.*|:.+|ifdef::|endif::|image::|include::|link::|video::).*$"
+  asciidoc_markup := "^(.*\\[.*\\]|\\/\\/.*|=+.*|<(\\.|\\d+)>.*|>|#+.*|\\..+|\\|.*|:.+|.*::|ifdef::|endif::|image::|include::|link::|video::).*$"
   listingblock_delim_regex := "^-{4}$"
   inside_listingblock := false
 

--- a/tengo-rule-scripts/HardWrappedLines.tengo
+++ b/tengo-rule-scripts/HardWrappedLines.tengo
@@ -21,7 +21,7 @@ sentence_regex := "^.*(\\.|\\?|\\!|:)$"
 list_regex := "^(\\.|\\*|-).*$"
 hard_wrap_80_regex := "^.{65,80}$"
 hard_wrap_100_regex := "^.{75,100}$"
-asciidoc_markup := "^(.*\\[.*\\]|\\/\\/.*|=+.*|<(\\.|\\d+)>.*|>|#+.*|\\..+|\\|.*|:.+|ifdef::|endif::|image::|include::|link::|video::).*$"
+asciidoc_markup := "^(.*\\[.*\\]|\\/\\/.*|=+.*|<(\\.|\\d+)>.*|>|#+.*|\\..+|\\|.*|:.+|.*::|ifdef::|endif::|image::|include::|link::|video::).*$"
 listingblock_delim_regex := "^-{4}$"
 inside_listingblock := false
 


### PR DESCRIPTION
DL lists with short explanations that don't take full stops should not trigger the hard-wrapped rule.

Eg., these are not complete sentence clauses and should not hit the rule
 
```asciidoc
Hard drive:: Permanent storage for operating system and/or user files that are used on a daily basis
RAM:: Temporarily stores information that the CPU uses during the math operation
```