### PR TITLE
Do not report common Linux terms

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -1,6 +1,7 @@
 // suppress inspection "IncorrectFormatting" for whole file
 a .NET application
 accessor
+ACLs
 adoc
 AGPLv
 Agroal
@@ -15,6 +16,8 @@ Applixware
 Asciidoctor
 AssertJ
 autolink
+automount
+Automount
 autostart
 Autostart
 aws
@@ -33,6 +36,8 @@ BOM
 Bonjour
 boolean
 Boolean
+bootable
+Bootable
 Bouncy Castle
 breakpoint
 Breakpoint
@@ -42,6 +47,7 @@ btn
 Btrfs
 Bugzilla
 build config
+Buildah
 camelCase
 CentOS
 Ceph
@@ -50,6 +56,8 @@ cgroup
 che
 Che
 Che-Theia
+chrony
+Chrony
 Ciphertext
 Civetweb
 ClassLoader
@@ -61,6 +69,8 @@ Cloudwashing
 CodeReady
 colocate
 Colocate
+colocation
+Colocation
 config
 Config
 config map
@@ -136,6 +146,7 @@ Fluentd
 Flyway
 Fortran
 Funqy
+Galera
 Gbps
 GCC
 GID
@@ -144,6 +155,10 @@ Git
 GitHub
 GitLab
 Gradle
+glock
+Glock
+glocks
+Glocks
 Gluster
 GNUPro
 GraalVM
@@ -203,11 +218,18 @@ JVM
 Kafka
 Kubernetes
 kbd
+kdump
+Kdump
+Kerberos
 Keycloak
 Keylime
 Keyring
 Keyrings
 keystore
+keytab
+Keytab
+keytabs
+Keytabs
 Kibana
 Knative
 Knowledgebase
@@ -221,6 +243,7 @@ Let's Encrypt
 LGPLv
 libOSMesa
 librados
+Libreswan
 librbd
 libvirt
 Libvirt
@@ -252,6 +275,7 @@ MongoDB
 Multicluster
 Multihost
 Multinode
+multipath
 Multipath
 Multitenant
 multithread
@@ -289,9 +313,11 @@ Operator
 OSBuild
 osd
 OSs
+OSTree
 overridable
 PCIe
 PDFs
+Petitboot
 PHP
 PIDs
 Podman
@@ -362,12 +388,14 @@ Serverless
 servlet
 Shadowman
 Sharding
+Skopeo
 SLA
 SLAs
 SmallRye
 Spotify
 startx
 STMicroelectronics
+Stratis
 su
 Subcommand
 Subcommands
@@ -409,6 +437,8 @@ Traefik
 Truststore
 Uber
 UIDs
+umask
+Umask
 Uncomment
 Undercloud
 Uninstallation

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -13,18 +13,22 @@ filters:
   - 'Node\.js'
   - "[aA]ccessor"
   - "[aA]llowlist"
+  - "[aA]utomount"
   - "[aA]utostart"
   - "[bB]ackfilling"
   - "[bB]ackported"
   - "[bB]acktrace"
   - "[bB]indable"
   - "[bB]oolean"
+  - "[bB]ootable"
   - "[bB]reakpoint"
   - "[bB]reakpoints"
   - "[cC]he"
+  - "[cC]hrony"
   - "[cC]lassloading"
   - "[cC]lasspath"
   - "[cC]olocate"
+  - "[cC]olocation"
   - "[cC]onfig"
   - "[cC]ustomizer"
   - "[dD]atasource"
@@ -48,6 +52,7 @@ filters:
   - "[fF]indability"
   - "[gG]bps"
   - "[gG]it"
+  - "[gG]locks?"
   - "[gG]radle"
   - "[gG]rafana"
   - "[hH]ardcoding"
@@ -59,10 +64,12 @@ filters:
   - "[jJ]et[bB]rains"
   - "[jJ]ournald"
   - "[jJ]ournaling"
+  - "[kK]dump"
   - "[kK]eycloak"
   - "[kK]eylime"
   - "[kK]eyring"
   - "[kK]eyrings"
+  - "[kK]eytabs?"
   - "[lL]ibvirt"
   - "[lL]icensor"
   - "[lL]iquibase"
@@ -79,6 +86,7 @@ filters:
   - "[mM]ulticluster"
   - "[mM]ultihost"
   - "[mM]ultinode"
+  - "[mM]ultipath"
   - "[mM]ultithread"
   - "[mM]ultitenant"
   - "[mM]ultiuser"
@@ -153,6 +161,7 @@ filters:
   - "[tT]olerations"
   - "[tT]raceback"
   - "[tT]ruststore"
+  - "[uU]mask"
   - "[uU]ncomment"
   - "[uU]ndercloud"
   - "[uU]ninstallation"
@@ -165,6 +174,7 @@ filters:
   - "[uU]pselling"
   - "[vV]alidator"
   - "Let\\'s Encrypt"
+  - ACLs
   - adoc
   - AGPLv
   - Agroal
@@ -188,6 +198,7 @@ filters:
   - btn
   - Btrfs
   - Bugzilla
+  - Buildah
   - camelCase
   - CentOS
   - Ceph
@@ -246,6 +257,7 @@ filters:
   - Flyway
   - Fortran
   - Funqy
+  - Galera
   - GCC
   - GIDs
   - GitHub
@@ -297,6 +309,7 @@ filters:
   - JVM
   - Kafka
   - kbd
+  - Kerberos
   - keystore
   - Kibana
   - Knative
@@ -311,6 +324,7 @@ filters:
   - LGPLv
   - librados
   - librbd
+  - Libreswan
   - libOSMesa
   - Logstash
   - Lombok
@@ -325,7 +339,6 @@ filters:
   - Mirantis
   - Mockito
   - MongoDB
-  - Multipath
   - MySQL
   - Nagios
   - Narayana
@@ -352,8 +365,10 @@ filters:
   - OSBuild
   - osd
   - OSs
+  - OSTree
   - PCIe
   - PDFs?
+  - Petitboot
   - PHP
   - PIDs
   - Podman
@@ -387,12 +402,14 @@ filters:
   - SCM
   - SELinux
   - Semeru
+  - Skopeo
   - Shadowman
   - SLAs
   - SmallRye
   - Spotify
   - startx
   - STMicroelectronics
+  - Stratis
   - Suchow
   - SVG
   - Symfony


### PR DESCRIPTION
Below is the list of Linux terms that are commonly used in Linux operating system documentation but are incorrectly regarded by `RedHat.Spelling` as errors. This produces an excessive number of false warnings in the documentation for Red Hat Enterprise Linux, in particular:

- 705× Kerberos
- 231× multipath
- 216× Stratis
- 126× ACLs
- 112× keytab
- 107× OSTree
- 54× Buildah
- 41× Skopeo
- ...

I went over the list of the most frequent false positives and tried to address them in this pull request.
