### PR TITLE
Detect problems in single-quote IDs

### DIFF
--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testinvalid.adoc
@@ -5,3 +5,19 @@
 //vale-fixture
 [id="rosa-getting-started]
 = Another guide to getting started
+
+//vale-fixture
+[id='rosa-getting-started_{context}]
+= Comprehensive guide to getting started with {product-title}
+
+//vale-fixture
+[id='rosa-getting-started]
+= Another guide to getting started
+
+//vale-fixture
+[id="rosa-getting-started']
+= Another guide to getting started
+
+//vale-fixture
+[id='rosa-getting-started"]
+= Another guide to getting started

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testvalid.adoc
@@ -2,3 +2,8 @@
 :_content-type: ASSEMBLY
 [id="rosa-getting-started_{context}"]
 = Comprehensive guide to getting started with {product-title}
+
+//vale-fixture
+:_content-type: ASSEMBLY
+[id='rosa-getting-started_{context}']
+= Comprehensive guide to getting started with {product-title}

--- a/.vale/styles/AsciiDoc/ClosedIdQuotes.yml
+++ b/.vale/styles/AsciiDoc/ClosedIdQuotes.yml
@@ -4,4 +4,4 @@ scope: raw
 level: error
 message: "Quoted ID value is not closed."
 raw:
-  - '(?<!.)\[id\=\".*(?<!\")\]'
+  - '(?<!.)\[id=(["\x27]).*(?<!\1)\]'


### PR DESCRIPTION
In addition to double quotes, AsciiDoc allows the use of single quotes around ID values, for example:

```
[id='some-name']
```

I extended the regular expression to report unclosed single-quote ID values as well as detect mismatched quotes:

```
[id='some-name]
[id='some-name"]
[id="some-name']
```