### PR TITLE
Write as shown: Appendixes

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -14,6 +14,7 @@ all right
 alright
 analyse
 and/or
+appendices
 as long as
 as per
 autodetect

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -12,6 +12,7 @@ AMD64
 and so on
 Apache Subversion
 app
+appendixes
 Application Load Balancer
 archive
 as

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -55,6 +55,7 @@ swap:
   alright|all right: "correct|as expected"
   analyse: analyze
   and/or: a or b|a, b, or both
+  appendices: appendixes
   as long as: if|provided that
   autodetect: auto-detect
   back-level: earlier|previous|not at the latest level


### PR DESCRIPTION
The IBM Style Guide strongly recommends using "Appendixes" instead of "Appendices". `RedHat.TermsErrors` already provides similar guidance for "matrices" and considering Red Hat documentation currently uses both variants in production, I think it would be valuable for Vale to start complaining about.