### PR TITLE
A few updates to the Error terms

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -414,3 +414,6 @@ xsite
 zero out
 zone-group
 zonegroup
+kilobytes
+do it w/ stuff.
+do it w/o stuff.

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -329,3 +329,6 @@ swap:
   xsite: cross-site replication
   zero out: zero
   zonegroup|zone-group: zone group
+  kilobytes?: KB|kB
+  'w/(?!o) ': "with "
+  'w/o': without


### PR DESCRIPTION
TermsErrors rule: 
```
  'w/(?!o) ': "with "
  'w/o': without
  kilobytes?: KB|kB
```