### PR TITLE
Adding guidance for arch terms after SSG was updated

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -27,3 +27,6 @@ Start using this.
 This clause which is nonrestrictive
 This clause, that is restrictive
 via
+x64
+x86-64
+x86

--- a/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
@@ -28,3 +28,5 @@ shell script
 this clause that is restrictive
 this clause, which is nonrestrictive
 through
+64-bit x86
+x86_64

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -19,3 +19,4 @@ swap:
   refer to: see
   segfault: segmentation fault
   via: through|by|from|on|by using
+  "x64|x86-64|(?<!64-bit )x86": 64-bit x86|x86_64


### PR DESCRIPTION
Fixes https://github.com/redhat-documentation/vale-at-red-hat/issues/199.

SSG was finalized with regard to terminology for different architiectures. Adding this back into Vale rules as a suggestion. 