### PR TITLE
Adding new product-centric writing rule

### DIFF
--- a/.vale/fixtures/RedHat/ProductCentricWriting/.vale.ini
+++ b/.vale/fixtures/RedHat/ProductCentricWriting/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `ProductCentricWriting` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.ProductCentricWriting = YES

--- a/.vale/fixtures/RedHat/ProductCentricWriting/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/ProductCentricWriting/testinvalid.adoc
@@ -1,0 +1,5 @@
+The tools allow customers to use a Kubernetes Network Policy to create microsegmentation between deployed application services on the cluster.
+The `monitoring-rules-edit` rule permits you to create and silence alerts in the *Developer* perspective in the web console.
+The `must-gather` tool enables the user to collect diagnostic information about your cluster.
+LoadBalancer lets users assign an external load balancer to an associated service API object in your {product-title} cluster.
+LoadBalancer lets you assign an external load balancer to an associated service API object in your {product-title} cluster.

--- a/.vale/styles/RedHat/ProductCentricWriting.yml
+++ b/.vale/styles/RedHat/ProductCentricWriting.yml
@@ -1,0 +1,8 @@
+---
+extends: existence
+ignorecase: true
+level: suggestion
+link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/productcentricwriting/
+message: Do not use transitive verb constructions like "%s" to grant abilities to inanimate objects. Whenever possible, use direct, user-focused sentences where the subject of the sentence performs the action.
+tokens:
+  - '(allows?|enables?|lets?|permits?)\s(you|customers|the customer|the user|users)'

--- a/modules/reference-guide/pages/productcentricwriting.adoc
+++ b/modules/reference-guide/pages/productcentricwriting.adoc
@@ -1,0 +1,12 @@
+:navtitle: Product-centric writing
+:keywords: product-centric, writing, anthropomorphism
+
+= Product-centric writing
+
+Do not use product-centric writing to grant abilities to inanimate objects. Where possible, make the user the subject of the sentence.
+
+.Additional resources
+
+* link:{ibmsg-url-print}[{ibmsg-print} - Anthropomorphism, p. 44]
+* link:{ibmsg-url}?topic=grammar-anthropomorphism[{ibmsg} - Anthropomorphism]
+


### PR DESCRIPTION
Based on this [How to put the customer first in your sentences](https://www.knowledgeowl.com/blog/posts/customer-first-in-your-sentences) article and a [slack message from Ingrid](https://redhat-internal.slack.com/archives/C04P5S34GP2/p1693151862297009), this rule flags "product-centric" sentence constructions suggesting that you rewrite the sentence in a more active and direct style.

![image](https://github.com/redhat-documentation/vale-at-red-hat/assets/74046732/8ec3a616-ed3e-4ee0-bf00-e3fb89ff1c3f)

