### PR TITLE
Adding Jaromir's fix from #366

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testvalid.adoc
@@ -26,7 +26,17 @@ see this section
 segmentation fault
 shell prompt
 shell script
-this clause that is restrictive
+something against which something else
+something at which something else
+something for which something else
+something from which something else
+something in which somehing else
+something of which something else
+something on which something else
+something to which something else
+something with which something else
+something without which something else
 this clause, which is nonrestrictive
 through
 x86_64
+

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -7,7 +7,7 @@ message: "Depending on the context, consider using '%s' rather than '%s'."
 action:
   name: replace
 swap:
-  "(?<!,) which": ", which| that"
+  "(?<!,| in| on| at| to| for| from| of| with| without| against) which": ", which| that"
   "(?<!.-)jar": compress|archive
   "(?<!by) using": " by using| that uses"
   ", that": ", which| that"


### PR DESCRIPTION
This PR uses @jhradilek's changes from https://github.com/redhat-documentation/vale-at-red-hat/pull/366 Thanks @jhradilek :)

Came across this error in my own writing and figured it was important enough to get this in. There are some wrinkles with how Asciidoctor renders HTML, line breaks, paragraphs, etc that possibly affect how our text fixtures work but we can deal with that seperately IMO. It's a Vale bug.