### PR TITLE
Add 'quickstart|Quickstart: quick start' to the Red Hat style guide

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -319,6 +319,8 @@ Programming Language/I
 proof of concepts
 pub/sub
 publish-subscribe
+quickstart
+Quickstart
 read-write
 recognise
 Red Hat Java

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -481,6 +481,7 @@ pseudo-ops
 pseudocode
 publish/subscribe
 pull-down
+quick start
 rather than
 re-create
 read/write

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -329,6 +329,7 @@ swap:
   Programming Language/I: PL/I
   proof of concepts: proofs of concept
   pub/sub|publish-subscribe: publish/subscribe
+  quickstart|Quickstart: quick start
   read-write: read/write
   recognise: recognize
   Red Hat Java: Red Hat build of OpenJDK


### PR DESCRIPTION
Update on issue #643 