### PR TITLE
Changing the module context rule as it doesn't highlight anything in VS Code 

### DIFF
--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -10,10 +10,10 @@
 == Eclipse Vert.x and Netty are upgraded in Quarkus
 == IBM Cloud
 == mTLS authentication
-== The mutual TLS authentication scheme
+//== The mutual TLS authentication scheme
 == Proof Key for Code Exchange
 == Kogito updates
-== IBM Cloud is a valid product name
+//== IBM Cloud is a valid product name
 //== Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
 == Redis is an in-memory data structure store that is used by several Red Hat products.
 == Repackage the JAR file

--- a/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
@@ -1,8 +1,29 @@
 ---
-extends: occurrence
-scope: raw
+extends: script
+message: "Module is missing the \":_mod-docs-content-type:\" variable."
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#module-file-metadata
-message: "Module is missing the \"_mod-docs-content-type\" variable."
-min: 1
-token: '(?<!\/\/):_mod-docs-content-type:(\s)?(CONCEPT|PROCEDURE|REFERENCE|ASSEMBLY|SNIPPET)'
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  //trim extra whitespace
+  scope = text.trim_space(scope)
+  //add a newline, it might be missing
+  scope += "\n"
+
+  context_regex := ":_mod-docs-content-type: (CONCEPT|SNIPPET|ASSEMBLY|PROCEDURE|REFERENCE)"
+  match := false
+
+  //Check if context declaration is on any line
+  for line in text.split(scope, "\n") {
+    if text.re_match(context_regex, line){
+      match = true
+    }
+    }
+
+  //Highlight first line if context declaration not found in file
+  if match == false {
+    matches = append(matches, {begin: 1, end: 10})
+        }

--- a/tengo-rule-scripts/ModuleContainsContextType.tengo
+++ b/tengo-rule-scripts/ModuleContainsContextType.tengo
@@ -1,0 +1,36 @@
+/*
+Tengo Language
+Checks that lines are not hard-wrapped.
+$ tengo HardWrappedLines.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+scope := os.read_file(input[2])
+matches := []
+
+  //trim extra whitespace
+  scope = text.trim_space(scope)
+  //add a newline, it might be missing
+  scope += "\n"
+
+  context_regex := ":_content-type: (CONCEPT|SNIPPET|ASSEMBLY|PROCEDURE|REFERENCE)"
+  match := false
+
+  //Check if context declaration is on any line
+  for line in text.split(scope, "\n") {
+    if text.re_match(context_regex, line){
+      match = true
+      fmt.println("Found content-type declaration")
+    } 
+    }
+
+  //Highlight first line if context declaration not found in file
+  if match == false {
+    matches = append(matches, {begin: 1, end: 10})
+    fmt.println("Did not find content-type declaration")
+    fmt.println(matches) 
+        }


### PR DESCRIPTION
The rule to check for the presence of the :_content-type: in a module works but it doesn't show any line highlighting in VS Code. It only show the error on the cmd line. 
This PR changes the rule to a tengo script, which highlights the first line of the file if it doesn't find the variable. 