### PR TITLE
Add "reentrant" to spelling rule

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -468,6 +468,7 @@ redirect
 Redis
 Redistributions
 reedit
+reentrant
 reexamine
 relaxngDatatype
 Reshard

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -155,6 +155,7 @@ filters:
   - "[rR]ebased"
   - "[rR]ecertification"
   - "[rR]ecertifications"
+  - "[rR]eentrant"
   - "[rR]eshard"
   - "[rR]esharding"
   - "[rR]eshards"


### PR DESCRIPTION
Fixes https://github.com/redhat-documentation/vale-at-red-hat/issues/673