### PR TITLE
Add valid component names to headings and capitalization rules

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -164,6 +164,7 @@ LDAPS
 librados
 librbd
 Linux
+Liquibase
 LUN
 management CLI
 management console
@@ -176,6 +177,7 @@ Microsoft Azure
 Microsoft Azure Cross-Platform Command-Line Interface
 Microsoft Azure On-Demand Marketplace
 Microsoft Azure portal
+Mockito
 MOM
 MongoDB
 ms
@@ -193,6 +195,7 @@ OK
 OKD
 OpenID Connect
 OpenRewrite
+OpenTelemetry
 operating environment
 operating system
 Operator Lifecycle Manager
@@ -200,6 +203,7 @@ OperatorHub
 OpEx
 Organization Administrator
 OSD
+OTel
 overcloud
 Podman
 pop-up
@@ -291,6 +295,7 @@ systemd
 SysV
 T-BC
 Technology Preview
+Temurin
 The .NET framework
 TLS handshake
 TTL

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -14,7 +14,7 @@
 == Proof Key for Code Exchange
 == Kogito updates
 == IBM Cloud is a valid product name
-//== Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
+== Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
 == Redis is an in-memory data structure store that is used by several Red Hat products.
 == Repackage the JAR file
 == Installing Podman Desktop
@@ -45,4 +45,7 @@
 == Problems with gRPC and xDS
 == Testing role-based access control in a heading
 == Testing RBAC in a heading
-
+== A Liquibase database
+== Using Mockito
+== Downloading the Eclipse Temurin distribution
+== Configuring OpenTelemetry

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -14,7 +14,7 @@
 == Proof Key for Code Exchange
 == Kogito updates
 == IBM Cloud is a valid product name
-== Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
+//== Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
 == Redis is an in-memory data structure store that is used by several Red Hat products.
 == Repackage the JAR file
 == Installing Podman Desktop

--- a/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
@@ -127,6 +127,7 @@ OperatorHub
 OpEx
 OSBuild
 OSs
+OTel
 PaaS
 PackageKit
 PathTools

--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -393,6 +393,7 @@ OpenID
 OpenJDK
 OpenRewrite
 OpenShift
+OpenTelemetry
 OpenTracing
 Operator
 OSBuild
@@ -560,6 +561,7 @@ Sysctl
 sysctls
 Sysctls
 Systemd
+Temurin
 Tekton
 Telekom
 Templated

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -208,6 +208,7 @@ swap:
   openid connect|Openid Connect: OpenID Connect
   openrewrite|Openrewrite|Open Rewrite: OpenRewrite
   Openshift online|OO: Red Hat OpenShift Online
+  Open Telemetry: OpenTelemetry (OTel)
   Operating Environment: operating environment
   Operator Hub|Operator hub|Operatorhub|operatorhub: OperatorHub
   Opex|Opex|OPEX|opEx: OpEx

--- a/.vale/styles/RedHat/Headings.yml
+++ b/.vale/styles/RedHat/Headings.yml
@@ -142,6 +142,7 @@ exceptions:
   - Kubespray
   - Kylin
   - Laravel
+  - Liquibase
   - Logstash
   - Lombok
   - Makefile
@@ -174,7 +175,9 @@ exceptions:
   - OpenJDK
   - OpenRewrite
   - OpenShift
+  - OpenTelemetry
   - OpenTracing
+  - OTel
   - PHP
   - Podman
   - Podman Desktop
@@ -215,6 +218,7 @@ exceptions:
   - Technology Preview
   - Tekton
   - Telekom
+  - Temurin
   - Tensorflow
   - Texinfo
   - Toolset

--- a/.vale/styles/RedHat/PascalCamelCase.yml
+++ b/.vale/styles/RedHat/PascalCamelCase.yml
@@ -131,6 +131,7 @@ exceptions:
   - OperatorHub
   - OpEx
   - OSBuild
+  - OTel
   - PaaS
   - PackageKit
   - PathTools

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -409,11 +409,13 @@ filters:
   - OpenJDK
   - OpenRewrite
   - OpenShift
+  - OpenTelemetry
   - OpenTracing
   - OSBuild
   - osd
   - OSs
   - OSTree
+  - OTel
   - PCIe
   - PDF
   - Petitboot
@@ -463,6 +465,7 @@ filters:
   - Symfony
   - Tekton
   - Telekom
+  - Temurin
   - Tensorflow
   - Texinfo
   - Toolset


### PR DESCRIPTION
This PR aims to reduce false positive heading warnings and adds guidance for capitalization in Red Hat style rules for the following names, which are commonly used in Red Hat Runtimes and developer products:

- Liquibase
- Mockito
- OpenTelemetry (OTel)
- OTel
- Temurin
