### PR TITLE
Fix heading and case-sensitive rule for role-based access control (RBAC)

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -253,7 +253,7 @@ Red Hat Virtualization Manager
 RedBoot
 Redis
 RESTEasy
-Role-based access control
+role-based access control
 Rolling Application Stream
 Rolling Application Streams
 Rolling Stream

--- a/.vale/fixtures/RedHat/Headings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Headings/testvalid.adoc
@@ -43,4 +43,6 @@
 == Uninstalling Logstash
 == About WebView
 == Problems with gRPC and xDS
+== Testing role-based access control in a heading
+== Testing RBAC in a heading
 

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -251,7 +251,7 @@ swap:
   RHDS: Red Hat Directory Server
   RHEL host|RHEL-H: Red Hat Enterprise Linux host
   RHV: Red Hat Virtualization
-  Role Based Access Control|Role-Based Access Control|role based access control: Role-based access control
+  Role Based Access Control|Role-Based Access Control|role based access control: role-based access control
   rolling application stream: Rolling Application Stream
   rolling application streams: Rolling Application Streams
   rolling stream: Rolling Stream


### PR DESCRIPTION
This PR makes a small correction to the style guidance rule for _role-based access control (RBAC)_.

This security term should be all lowercase (no capital _R_ in Role), unless at the start of a sentence, which is already detected and handled by vale-at-red-hat rules.


