### PR TITLE
Update recommended vale extension

### DIFF
--- a/modules/user-guide/pages/using-vale-in-the-ide.adoc
+++ b/modules/user-guide/pages/using-vale-in-the-ide.adoc
@@ -32,5 +32,5 @@ Consider using Vale in your IDE when:
 
 .Additional resources
 
-* link:https://github.com/errata-ai/vale-vscode[Visual Studio Code extension for Vale repository and documentation]
+* link:https://github.com/chrischinchilla/vale-vscode[Visual Studio Code extension for Vale repository and documentation]
 * link:https://vale.sh/docs/integrations/guide/[How to integrate Vale with other tools and services]

--- a/modules/user-guide/pages/using-vale-in-the-ide.adoc
+++ b/modules/user-guide/pages/using-vale-in-the-ide.adoc
@@ -20,7 +20,7 @@ Consider using Vale in your IDE when:
 
 .Procedure
 
-. In  Visual Studio Code, install the link:https://marketplace.visualstudio.com/items?itemName=errata-ai.vale-server[Visual Studio Code extension for Vale using the Marketplace].
+. In  Visual Studio Code, install the link:https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode[Visual Studio Code extension for Vale using the Marketplace].
 
 . Restart Visual Studio Code.
 


### PR DESCRIPTION
The currently mentioned extension is deprecated and VS Code will suggest to use this newer extension.