### PR TITLE
Added rule: for instance

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -470,3 +470,4 @@ zero out
 zeroes
 zonegroup
 Zulu time
+There are many ways to write, for instance, using a pencil.

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -695,3 +695,4 @@ workstation
 zero
 zeros
 zone group
+Configuring the Compute Service for Instance Creation. Support for instance domain change-deltas, and for instances where.

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -39,6 +39,7 @@ swap:
   "w/o": without
   '(?<!IBM\s)S\/390|S90|S\s390': IBM S/390
   'backwards?\scompatible': compatible with earlier versions
+  '(?<= )for instance(?=,)': for example
   10BASE-2: 10BASE2
   10BASET: 10BASE-T
   24/7: 24x7


### PR DESCRIPTION
Fixes #687 

New rule: Checks if there is a space before and a comma following "for instance". 

**question:** ❔ Should we also check for "for instance" with spaces before and after?