### PR TITLE
vale-issue-672 - Use double quotes not single quotes in IDs

### DIFF
--- a/.vale/fixtures/AsciiDoc/DoubleQuotes/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/DoubleQuotes/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `OxfordComma` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+AsciiDoc.DoubleQuotes = YES

--- a/.vale/fixtures/AsciiDoc/DoubleQuotes/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/DoubleQuotes/testinvalid.adoc
@@ -1,0 +1,2 @@
+id='support-overview-remote-health-monitoring'
+id='id-value'

--- a/.vale/fixtures/AsciiDoc/DoubleQuotes/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/DoubleQuotes/testvalid.adoc
@@ -1,0 +1,2 @@
+id="support-overview-remote-health-monitoring"
+id="id-value"

--- a/.vale/styles/AsciiDoc/DoubleQuotes.yml
+++ b/.vale/styles/AsciiDoc/DoubleQuotes.yml
@@ -1,0 +1,7 @@
+---
+extends: existence
+level: suggestion
+message: "Use double quotes instead of single quotes for IDs"
+nonword: true
+raw:
+  - "id='.*'"


### PR DESCRIPTION
This PR addresses #672

My regex knowledge leaves a lot to be disired but I made an attempt at adding this rule.

As it relates to AsciiDoc syntax, I added to the AsciiDoc package.

The tests pass when I run `vale .` but this could do with a sanity check.

Any and all feedback welcome :)