### PR TITLE
Replacing double quotes in alert messages with single quotes.

### DIFF
--- a/.vale/styles/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID.yml
@@ -4,7 +4,7 @@ scope: raw
 level: suggestion
 nonword: true
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#additional-resources-sections
-message: "Additional resources heading is missing the \"_additional-resources\" role attribute declaration"
+message: "Additional resources heading is missing the '_additional-resources' role attribute declaration"
 tokens:
   - '(?<!\/\/)(?<!\[role="_additional-resources"\]\n)\.Additional resources'
   - '(?<!\/\/)(?<!\[role="_additional-resources"\]\n)^=+ Additional resources'  

--- a/.vale/styles/OpenShiftAsciiDoc/IdHasContextVariable.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/IdHasContextVariable.yml
@@ -3,6 +3,6 @@ extends: existence
 scope: raw
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#anchoring-in-module-files
-message: "ID is missing the \"_{context}\" variable at the end of the ID."
+message: "ID is missing the '_{context}' variable at the end of the ID."
 raw:
   - '(?<!\/\/)\[id(?!.*_{context})'

--- a/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
@@ -3,6 +3,6 @@ extends: occurrence
 scope: raw
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#module-file-metadata
-message: "Module is missing the \"_mod-docs-content-type\" variable."
+message: "Module is missing the '_mod-docs-content-type' variable."
 min: 1
 token: '(?<!\/\/):_mod-docs-content-type:(\s)?(CONCEPT|PROCEDURE|REFERENCE|ASSEMBLY|SNIPPET)'


### PR DESCRIPTION
 Double quotes within the message body causes problems for further processing with other programs. For example, I get confused JSON converting to JSON
 
 `{"body":"Module is missing the "_mod-docs-content-type" variable.","path":"test.adoc","line":1}`
 
 Changing the 3 instances in the OCP rule set so it will read like the following, which is easier JSON to process.
 
` {"body":"Module is missing the '_mod-docs-content-type' variable.","path":"test.adoc","line":1}`
 
 Using single quotes in messages is also the format used in other rule sets.