### PR TITLE
remove AI from error terms

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -10,7 +10,6 @@ adapter card
 adaptor
 administrate
 adviser
-AI
 air wall
 aka
 all right

--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -41,7 +41,6 @@ as expected
 as in
 as needed
 as well as per recipient
-Assisted Installer
 attacker
 attention notice
 auto-detect

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -21,7 +21,6 @@ swap:
   "(?<!self-)hosted engine|hosted-engine": self-hosted engine
   "[bB]asic [aA]uth": Basic HTTP authentication|Basic authentication
   "a lot(?: of)?": many|much
-  "AI": Assisted Installer
   "best of breed|best-of-breed": best in class
   "bottle neck|bottle-neck": bottleneck
   "Christian name|forename|first name": given name


### PR DESCRIPTION
AI is more commonly understood to mean Artificial Intelligence, not Assisted Installer. This rule is misleading