### PR TITLE
Adding unset attribute rule

### DIFF
--- a/.vale/fixtures/AsciiDoc/UnsetAttributes/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/UnsetAttributes/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `UnsetAttributes` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+AsciiDoc.UnsetAttributes = YES

--- a/.vale/fixtures/AsciiDoc/UnsetAttributes/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/UnsetAttributes/testinvalid.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: PROCEDURE
+:context: creating-infrastructure-machinesets
+= Testing
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:infra: test
+endif::[]
+
+Vale reports lots of errors, it should also report an attribute that you forgot to unset
+
+////
+Ignore multi-line comments
+:!infra:
+////
+
+//ignore comments
+//:!infra:

--- a/.vale/fixtures/AsciiDoc/UnsetAttributes/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/UnsetAttributes/testvalid.adoc
@@ -1,0 +1,20 @@
+:context: creating-infrastructure-machinesets
+:_mod-docs-content-type: ASSEMBLY
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+//vale-fixture
+:type: Go
+endif::[]
+
+Vale reports lots of errors, it should also report an attribute that you forgot to unset
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+//vale-fixture
+:!type:
+endif::[]
+
+//This is really just unsetting a second time, but it should not trip the rule
+ifeval::["{context}" == "creating-infrastructure"]
+//vale-fixture
+:type!:
+endif::[]

--- a/.vale/styles/AsciiDoc/UnsetAttributes.yml
+++ b/.vale/styles/AsciiDoc/UnsetAttributes.yml
@@ -1,0 +1,49 @@
+---
+extends: script
+level: error
+message: "Set attribute directive does not have a corresponding unset attribute directive."
+link: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/#unset-a-document-attribute-in-the-body
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  // trim extra whitespace
+  scope = text.trim_space(scope)
+  // add a newline, it might be missing
+  scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+
+  attr_regex := "^:[\\w-_]+:.*$"
+  context_mod_docs_regex := "^:context|_mod-docs-content-type:.*$"
+  attr_name_regex := ":[\\w-_]+:"
+  attr_name := ""
+  unset_attr_pref := ""
+  unset_attr_suff := ""
+
+  for line in text.split(scope, "\n") {
+    if text.re_match(attr_regex, line) {
+      if !text.re_match(context_mod_docs_regex, line) {
+        start := text.index(scope, line)
+        matches = append(matches, {begin: start, end: start + len(line)})
+        // re_find returns an array holding all matches
+        attr_name = ((text.re_find(attr_name_regex, line))[0][0])["text"]
+        unset_attr_pref = `^:!` + text.trim_prefix(attr_name, `:`)
+        unset_attr_suff = `^` + text.trim_suffix(attr_name, `:`) + `!:`
+        // loop through lines for every attr found
+        for line in text.split(scope, "\n") {
+          if text.re_match(unset_attr_pref, line) {
+            if len(matches) > 0 {
+              // remove the most recently added match
+              matches = matches[:len(matches)-1]
+            } else if text.re_match(unset_attr_suff, line) {
+              if len(matches) > 0 {
+                matches = matches[:len(matches)-1]
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/tengo-rule-scripts/UnsetAttributes.tengo
+++ b/tengo-rule-scripts/UnsetAttributes.tengo
@@ -1,0 +1,58 @@
+/*
+Tengo Language
+$ tengo UnsetAttributes.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+scope := os.read_file(input[2])
+matches := []
+
+// trim extra whitespace
+scope = text.trim_space(scope)
+// add a newline, it might be missing
+scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+
+attr_regex := "^:[\\w-_]+:.*$"
+context_mod_docs_regex := "^:context|_mod-docs-content-type:.*$"
+attr_name_regex := ":[\\w-_]+:"
+attr_name := ""
+unset_attr_pref := ""
+unset_attr_suff := ""
+
+for line in text.split(scope, "\n") {
+  if text.re_match(attr_regex, line) {
+    if !text.re_match(context_mod_docs_regex, line) {
+      start := text.index(scope, line)
+      matches = append(matches, {begin: start, end: start + len(line)})
+      // re_find returns an array holding all matches
+      attr_name = ((text.re_find(attr_name_regex, line))[0][0])["text"]
+      unset_attr_pref = `^:!` + text.trim_prefix(attr_name, `:`)
+      unset_attr_suff = `^` + text.trim_suffix(attr_name, `:`) + `!:`
+      // loop through lines for every attr found
+      for line in text.split(scope, "\n") {
+        if text.re_match(unset_attr_pref, line) {
+          if len(matches) > 0 {
+            // remove the most recently added match
+            matches = matches[:len(matches)-1]
+          } else if text.re_match(unset_attr_suff, line) {
+            if len(matches) > 0 {
+              matches = matches[:len(matches)-1]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+if len(matches) == 0 {
+  fmt.println("Attributes are unset properly")
+} else {
+  fmt.println(matches)
+}


### PR DESCRIPTION
Adds a new AsciiDoc rule that highlights when an attribute is not unset in the same file. 

The rule fires for an attribute that is not unset in the file.