### PR TITLE
Clean out multi-line AsciiDoc comments in raw script rules

### DIFF
--- a/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   num_codeblock_callouts := 0
   num_callouts := 0

--- a/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   codeblock_callout_regex := ".+(<\\d+>)+"
   callout_regex := "^<(\\d+)>"

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   prev_num := 0
   callout_regex := "^<(\\d+)>"

--- a/.vale/styles/AsciiDoc/ValidAdmonitionBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidAdmonitionBlocks.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   admon_delim_regex := "^={4}$"
   count := 0

--- a/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   listingblock_delim_regex := "^-{4}$"
   count := 0

--- a/.vale/styles/AsciiDoc/ValidConditions.yml
+++ b/.vale/styles/AsciiDoc/ValidConditions.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   if_regex := "^(ifdef::.+\\[\\]|ifndef::.+\\[\\]|ifeval::.*)"
   endif_regex := "^endif::.*"

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.yml
@@ -12,6 +12,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   tbl_delim_regex := "^\\|={3,}$"
   count := 0

--- a/.vale/styles/OpenShiftAsciiDoc/HardWrappedLines.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/HardWrappedLines.yml
@@ -11,6 +11,8 @@ script: |
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
+  // clean out multi-line comments
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
   sentence_regex := "^.*(\\.|\\?|\\!|:)$"
   list_regex := "^(\\.|\\*|-).*$"

--- a/tengo-rule-scripts/HardWrappedLines.tengo
+++ b/tengo-rule-scripts/HardWrappedLines.tengo
@@ -16,6 +16,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 sentence_regex := "^.*(\\.|\\?|\\!|:)$"
 list_regex := "^(\\.|\\*|-).*$"

--- a/tengo-rule-scripts/MatchingDotCallouts.tengo
+++ b/tengo-rule-scripts/MatchingDotCallouts.tengo
@@ -16,6 +16,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 num_codeblock_callouts := 0
 num_callouts := 0

--- a/tengo-rule-scripts/MatchingNumberedCallouts.tengo
+++ b/tengo-rule-scripts/MatchingNumberedCallouts.tengo
@@ -16,6 +16,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 codeblock_callout_regex := ".+(<\\d+>)+"
 callout_regex := "^<(\\d+)>"

--- a/tengo-rule-scripts/SequentialNumberedCallouts.tengo
+++ b/tengo-rule-scripts/SequentialNumberedCallouts.tengo
@@ -16,6 +16,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 prev_num := 0
 callout_regex := "^<(\\d+)>"

--- a/tengo-rule-scripts/ValidAdmonitionBlocks.tengo
+++ b/tengo-rule-scripts/ValidAdmonitionBlocks.tengo
@@ -15,6 +15,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 admon_delim_regex := "^={4,}$"
 count := 0

--- a/tengo-rule-scripts/ValidCodeBlocks.tengo
+++ b/tengo-rule-scripts/ValidCodeBlocks.tengo
@@ -15,6 +15,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 codeblock_delim_regex := "^-{4,}$"
 source_block_regex := "^\\[(source|subs|role).*\\]"

--- a/tengo-rule-scripts/ValidConditions.tengo
+++ b/tengo-rule-scripts/ValidConditions.tengo
@@ -15,6 +15,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 if_regex := "^(ifdef::.+\\[\\]|ifndef::.+\\[\\]|ifeval::.*)"
 endif_regex := "^endif::.*"

--- a/tengo-rule-scripts/ValidTableBlocks.tengo
+++ b/tengo-rule-scripts/ValidTableBlocks.tengo
@@ -15,6 +15,8 @@ matches := []
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
+// clean out multi-line comments
+scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
 
 tbl_delim_regex := "^\\|={3,}$"
 count := 0


### PR DESCRIPTION
Since script rules operate on raw AsciiDoc (not HTML), the rules need to handle commented content explicitly.

This update cleans out the comments before linting the source file.

```
// clean out multi-line comments
scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
```