### PR TITLE
Editing alert message as the line number of the alert may not be where the problem is

### DIFF
--- a/.vale/styles/AsciiDoc/ValidConditions.yml
+++ b/.vale/styles/AsciiDoc/ValidConditions.yml
@@ -1,7 +1,7 @@
 ---
 extends: script
 level: error
-message: "File contains unbalanced if statements."
+message: "File contains unbalanced if statements. Review the file to ensure it contains matching opening and closing if statements."
 link: https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/
 scope: raw
 script: |


### PR DESCRIPTION
Making it clearer that the user should search the entire file unbalanced if statements, not just the line where the alert is triggering.