### PR TITLE
Fix whitespace errors

### DIFF
--- a/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/testvalid.adoc
@@ -22,7 +22,7 @@ $ oc adm must-gather
 
 //vale-fixture
 .Example API response
-[source,json]
+[source,json] 
 ----
 [
  {

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testinvalid.adoc
@@ -3,7 +3,7 @@
 = Comprehensive guide to getting started with {product-title}
 
 //vale-fixture
-[id="rosa-getting-started]
+[id="rosa-getting-started] 
 = Another guide to getting started
 
 //vale-fixture

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testvalid.adoc
@@ -1,6 +1,6 @@
 //vale-fixture
 :_mod-docs-content-type: ASSEMBLY
-[id="rosa-getting-started_{context}"]
+[id="rosa-getting-started_{context}"] 
 = Comprehensive guide to getting started with {product-title}
 
 //vale-fixture

--- a/.vale/fixtures/AsciiDoc/ImageContainsAltText/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ImageContainsAltText/testinvalid.adoc
@@ -1,2 +1,2 @@
 //vale-fixture
-image::my-image-name.png[]
+image::my-image-name.png[] 

--- a/.vale/fixtures/AsciiDoc/ImageContainsAltText/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ImageContainsAltText/testvalid.adoc
@@ -1,2 +1,2 @@
 //Correct usage of alt text in image tags
-image::my-image-name.png[my-image-alt-text]
+image::my-image-name.png[my-image-alt-text] 

--- a/.vale/fixtures/AsciiDoc/LinkContainsLinkText/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/LinkContainsLinkText/testinvalid.adoc
@@ -5,7 +5,7 @@ link:https://docs.aws.amazon.com/[]
 link:https://docs.aws.amazon.com/[Click here]
 
 //vale-fixture
-link:https://docs.aws.amazon.com/[click here]
+link:https://docs.aws.amazon.com/[click here] 
 
 //vale-fixture
 link:https://docs.aws.amazon.com/[here]

--- a/.vale/fixtures/AsciiDoc/MatchingDotCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/MatchingDotCallouts/testvalid.adoc
@@ -4,7 +4,7 @@
 require 'sinatra' <.>
 
 get '/hi' do <.>
-  "Hello World!" <.>
+  "Hello World!" <.> 
 end
 ----
 <.> Library import

--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testinvalid.adoc
@@ -12,7 +12,7 @@ get '/hihi'<2><3>
 //vale-fixture
 [source,ruby]
 ----
-require 'frankie' <1>
+require 'frankie' <1> 
 get '/hihihi' <2>
 ----
 <1> text!

--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testvalid.adoc
@@ -17,7 +17,7 @@ end
 require 'sinatra' \\//<1>
 
 get '/hi' do <2><3>
-  "Hello World!"<4>
+  "Hello World!"<4> 
 end
 ----
 <1> Library import

--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
@@ -19,7 +19,7 @@ require 'sinatra' <1>
 get '/hi' do <1>
   "Hello World!"
 end
-key: value <2>
+key: value <2> 
 ----
 <1> Library import
 <2> URL mapping

--- a/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/testinvalid.adoc
@@ -3,7 +3,7 @@ Here is a Admonition block:
 
 [IMPORTANT]
 .Feeding the Werewolves
-====
+==== 
 While werewolves are hardy community members, keep in mind the following dietary concerns:
 
 . They are allergic to cinnamon.

--- a/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/testvalid.adoc
@@ -3,7 +3,7 @@ Here is a Admonition block:
 
 [IMPORTANT]
 .Feeding the Werewolves
-====
+==== 
 While werewolves are hardy community members, keep in mind the following dietary concerns:
 
 . They are allergic to cinnamon.

--- a/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testinvalid.adoc
@@ -16,7 +16,7 @@ $ pwd
 Here is a code block:
 
 [source,yaml]
-----
+---- 
 ---
 apiVersion: 4.11
 

--- a/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testvalid.adoc
@@ -9,7 +9,7 @@ $ pwd
 Here is a another code block:
 
 [source,java]
-----
+---- 
 $ pwd
 ----
 

--- a/.vale/fixtures/AsciiDoc/ValidConditions/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidConditions/testinvalid.adoc
@@ -13,7 +13,7 @@ ifdef::revnumber[]
 This document has a version number of {revnumber}.
 
 //vale-fixture
-ifeval::[2 > 1]
+ifeval::[2 > 1] 
 Some text!
 
 //vale-fixture

--- a/.vale/fixtures/AsciiDoc/ValidConditions/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidConditions/testvalid.adoc
@@ -11,7 +11,7 @@ So much content in this section, I'd get confused.
 endif::[]
 
 //vale-fixture
-ifdef::revnumber[]
+ifdef::revnumber[] 
 This document has a version number of {revnumber}.
 endif::[]
 

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
@@ -21,7 +21,7 @@ Some text.
 
 .Table three
 [options="header"]
-|====
+|==== 
 |Column Title|Column Title|Column Title
 |content|content|content
 |====

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testvalid.adoc
@@ -14,7 +14,7 @@ Some text.
 //vale-fixture
 .Table two
 [options="header"]
-|====
+|==== 
 |Column Title|Column Title
 |content|content
 This content goes on and on.

--- a/.vale/fixtures/OpenShiftAsciiDoc/HardWrappedLines/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/HardWrappedLines/testvalid.adoc
@@ -17,7 +17,7 @@
 |TorqueBox
 |Application Server <1>
 |====
-<1> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse cursus urna
+<1> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse cursus urna 
 <2> Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
 [cols=2*, width="90%", options="header"]
@@ -69,7 +69,7 @@ Bullet lists are OK.
 ** Lorem ipsum dolor sit amet consectetur adipiscing elit furp
 * three
 
-. Lists are ok Lorem ipsum dolor sit amet consectetur adipiscing elit furp
+. Lists are ok Lorem ipsum dolor sit amet consectetur adipiscing elit furp 
 .. Lists are ok Lorem ipsum dolor sit amet consectetur adipiscing elit furp
 
 - Lists are ok Lorem ipsum dolor sit amet consectetur adipiscing elit furp

--- a/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
@@ -8,12 +8,10 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   num_codeblock_callouts := 0
   num_callouts := 0
@@ -21,6 +19,8 @@ script: |
   callout_regex := "^<(\\.)>"
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     if text.re_match(codeblock_callout_regex, line) {
       //restart for new listingblock
       num_callouts = 0

--- a/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
@@ -8,12 +8,10 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   codeblock_callout_regex := ".+(<\\d+>)+"
   callout_regex := "^<(\\d+)>"
@@ -25,6 +23,8 @@ script: |
   num_lines := len(text.split(scope, "\n"))
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     if text.re_match(codeblock_callout_regex, line) {
       inside = true
       //account for lines with multiple callouts

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -8,18 +8,18 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   prev_num := 0
   callout_regex := "^<(\\d+)>"
   listingblock_delim_regex := "^-{4,}$"
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     //reset count if we hit a listing block delimiter
     if text.re_match(listingblock_delim_regex, line) {
       prev_num = 0

--- a/.vale/styles/AsciiDoc/ValidAdmonitionBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidAdmonitionBlocks.yml
@@ -8,17 +8,17 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   admon_delim_regex := "^={4}$"
   count := 0
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     if text.re_match(admon_delim_regex, line) {
       count += 1
       start := text.index(scope, line)

--- a/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
@@ -8,17 +8,17 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   listingblock_delim_regex := "^-{4}$"
   count := 0
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     if text.re_match(listingblock_delim_regex, line) {
       count += 1
       start := text.index(scope, line)

--- a/.vale/styles/AsciiDoc/ValidConditions.yml
+++ b/.vale/styles/AsciiDoc/ValidConditions.yml
@@ -8,17 +8,17 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   if_regex := "^(ifdef::.+\\[\\]|ifndef::.+\\[\\]|ifeval::.*)"
   endif_regex := "^endif::.*"
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     if text.re_match(if_regex, line) {
       start := text.index(scope, line)
       matches = append(matches, {begin: start, end: start + len(line)})

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.yml
@@ -8,17 +8,17 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   tbl_delim_regex := "^\\|={3,}$"
   count := 0
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     if text.re_match(tbl_delim_regex, line) {
       count += 1
       start := text.index(scope, line)

--- a/.vale/styles/OpenShiftAsciiDoc/HardWrappedLines.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/HardWrappedLines.yml
@@ -7,12 +7,10 @@ script: |
   text := import("text")
   matches := []
 
-  //trim extra whitespace
-  scope = text.trim_space(scope)
-  //add a newline, it might be missing
-  scope += "\n"
   // clean out multi-line comments
   scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  //add a newline, it might be missing
+  scope += "\n"
 
   sentence_regex := "^.*(\\.|\\?|\\!|:)$"
   list_regex := "^(\\.|\\*|-).*$"
@@ -23,6 +21,8 @@ script: |
   inside_listingblock := false
 
   for line in text.split(scope, "\n") {
+    // trim trailing whitespace
+    line = text.trim_space(line)
     //ignore content in codeblocks
     if text.re_match(listingblock_delim_regex, line) && inside_listingblock == false {
       inside_listingblock = true

--- a/tengo-rule-scripts/HardWrappedLines.tengo
+++ b/tengo-rule-scripts/HardWrappedLines.tengo
@@ -12,12 +12,10 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 sentence_regex := "^.*(\\.|\\?|\\!|:)$"
 list_regex := "^(\\.|\\*|-).*$"
@@ -28,6 +26,8 @@ listingblock_delim_regex := "^-{4}$"
 inside_listingblock := false
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   //ignore content in codeblocks
   if text.re_match(listingblock_delim_regex, line) && inside_listingblock == false {
     inside_listingblock = true

--- a/tengo-rule-scripts/MatchingDotCallouts.tengo
+++ b/tengo-rule-scripts/MatchingDotCallouts.tengo
@@ -12,12 +12,10 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 num_codeblock_callouts := 0
 num_callouts := 0
@@ -25,6 +23,8 @@ codeblock_callout_regex := ".+<(\\.)>"
 callout_regex := "^<(\\.)>"
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   if text.re_match(codeblock_callout_regex, line) {
     //restart for new listingblock
     num_callouts = 0

--- a/tengo-rule-scripts/MatchingNumberedCallouts.tengo
+++ b/tengo-rule-scripts/MatchingNumberedCallouts.tengo
@@ -12,12 +12,10 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 codeblock_callout_regex := ".+(<\\d+>)+"
 callout_regex := "^<(\\d+)>"
@@ -29,6 +27,8 @@ num_callouts := 0
 num_lines := len(text.split(scope, "\n"))
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   if text.re_match(codeblock_callout_regex, line) {
     inside = true
     //account for lines with multiple callouts

--- a/tengo-rule-scripts/SequentialNumberedCallouts.tengo
+++ b/tengo-rule-scripts/SequentialNumberedCallouts.tengo
@@ -12,18 +12,18 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 prev_num := 0
 callout_regex := "^<(\\d+)>"
 listingblock_delim_regex := "^-{4,}$"
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   //reset count if we hit a listing block delimiter
   if text.re_match(listingblock_delim_regex, line) {
     prev_num = 0

--- a/tengo-rule-scripts/ValidAdmonitionBlocks.tengo
+++ b/tengo-rule-scripts/ValidAdmonitionBlocks.tengo
@@ -11,17 +11,17 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 admon_delim_regex := "^={4,}$"
 count := 0
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   if text.re_match(admon_delim_regex, line) {
     count += 1
     start := text.index(scope, line)

--- a/tengo-rule-scripts/ValidCodeBlocks.tengo
+++ b/tengo-rule-scripts/ValidCodeBlocks.tengo
@@ -11,18 +11,18 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 codeblock_delim_regex := "^-{4,}$"
 source_block_regex := "^\\[(source|subs|role).*\\]"
 sources_blocks := 0
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   if text.re_match(codeblock_delim_regex, line){
     start := text.index(scope, line)
     matches = append(matches, {begin: start, end: start + len(line)})  

--- a/tengo-rule-scripts/ValidConditions.tengo
+++ b/tengo-rule-scripts/ValidConditions.tengo
@@ -11,17 +11,17 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 if_regex := "^(ifdef::.+\\[\\]|ifndef::.+\\[\\]|ifeval::.*)"
 endif_regex := "^endif::.*"
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   if text.re_match(if_regex, line) {
     start := text.index(scope, line)
     matches = append(matches, {begin: start, end: start + len(line)})

--- a/tengo-rule-scripts/ValidTableBlocks.tengo
+++ b/tengo-rule-scripts/ValidTableBlocks.tengo
@@ -11,17 +11,17 @@ input := os.args()
 scope := os.read_file(input[2])
 matches := []
 
-//trim extra whitespace
-scope = text.trim_space(scope)
-//add a newline, it might be missing
-scope += "\n"
 // clean out multi-line comments
 scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+//add a newline, it might be missing
+scope += "\n"
 
 tbl_delim_regex := "^\\|={3,}$"
 count := 0
 
 for line in text.split(scope, "\n") {
+  // trim trailing whitespace
+  line = text.trim_space(line)
   if text.re_match(tbl_delim_regex, line) {
     count += 1
     start := text.index(scope, line)


### PR DESCRIPTION
Previously, script rules used `text.trim_space(scope)` to trim whitespace. This trimmed whitespace at the end of the scope only. It should be applied on each line instead.

Test results:
```
┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/
ClosedAttributeBlocks/      LinkContainsLinkText/       SequentialNumberedCallouts/ ValidConditions/
ClosedIdQuotes/             MatchingDotCallouts/        ValidAdmonitionBlocks/      ValidTableBlocks/
ImageContainsAltText/       MatchingNumberedCallouts/   ValidCodeBlocks/            

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks (whitespace-fix)
$ vale .

 testinvalid.adoc
 3:1  error  Attribute block is not closed.  AsciiDoc.ClosedAttributeBlocks 
 8:1  error  Attribute block is not closed.  AsciiDoc.ClosedAttributeBlocks 

✖ 2 errors, 0 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ClosedIdQuotes/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ClosedIdQuotes (whitespace-fix)
$ vale .

 testinvalid.adoc
 2:1   error  Quoted ID value is not closed.  AsciiDoc.ClosedIdQuotes 
 6:1   error  Quoted ID value is not closed.  AsciiDoc.ClosedIdQuotes 
 10:1  error  Quoted ID value is not closed.  AsciiDoc.ClosedIdQuotes 
 14:1  error  Quoted ID value is not closed.  AsciiDoc.ClosedIdQuotes 
 18:1  error  Quoted ID value is not closed.  AsciiDoc.ClosedIdQuotes 
 22:1  error  Quoted ID value is not closed.  AsciiDoc.ClosedIdQuotes 

✖ 6 errors, 0 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ClosedIdQuotes (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ImageContainsAltText/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ImageContainsAltText (whitespace-fix)
$ vale .

 testinvalid.adoc
 2:1  warning  Image is missing accessibility  AsciiDoc.ImageContainsAltText 
               alt tags.                                                     

✖ 0 errors, 1 warning and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ImageContainsAltText (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/LinkContainsLinkText/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/LinkContainsLinkText (whitespace-fix)
$ vale .

 testinvalid.adoc
 2:1   warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  
 5:1   warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  
 8:1   warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  
 11:1  warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  
 14:1  warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  
 17:1  warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  
 20:1  warning  Link is missing descriptive     AsciiDoc.LinkContainsLinkText 
                link text for accessibility.                                  

✖ 0 errors, 7 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/LinkContainsLinkText (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/MatchingDotCallouts/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/MatchingDotCallouts (whitespace-fix)
$ vale .

 testinvalid.adoc
 13:1  warning  Corresponding callout not       AsciiDoc.MatchingDotCallouts 
                found.                                                       
 25:1  warning  Corresponding callout not       AsciiDoc.MatchingDotCallouts 
                found.                                                       

✖ 0 errors, 2 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/MatchingDotCallouts (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts (whitespace-fix)
$ vale .

 testinvalid.adoc
 10:1  warning  Corresponding callout not       AsciiDoc.MatchingNumberedCallouts 
                found.                                                            
 21:1  warning  Corresponding callout not       AsciiDoc.MatchingNumberedCallouts 
                found.                                                            
 32:1  warning  Corresponding callout not       AsciiDoc.MatchingNumberedCallouts 
                found.                                                            

✖ 0 errors, 3 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts (whitespace-fix)
$ vale .

 testinvalid.adoc
 18:1  warning  Numbered callout does not       AsciiDoc.SequentialNumberedCallouts 
                follow sequentially.                                                
 31:1  warning  Numbered callout does not       AsciiDoc.SequentialNumberedCallouts 
                follow sequentially.                                                

✖ 0 errors, 2 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/ 

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks (whitespace-fix)
$ vale .

 testinvalid.adoc
 6:1  error  Unterminated admonition block   AsciiDoc.ValidAdmonitionBlocks 
             found in file.                                                 

✖ 1 error, 0 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidCodeBlocks/ 

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidCodeBlocks (whitespace-fix)
$ vale .

 testinvalid.adoc
 5:1  error  Unterminated listing block      AsciiDoc.ValidCodeBlocks 
             found in file.                                           

✖ 1 error, 0 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidCodeBlocks (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidConditions/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidConditions (whitespace-fix)
$ vale .

 testinvalid.adoc
 2:1   error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 6:1   error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 12:1  error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 16:1  error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 20:1  error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 24:1  error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 28:1  error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           
 32:1  error  File contains unbalanced        AsciiDoc.ValidConditions 
              if statements. Review the                                
              file to ensure it contains                               
              matching opening and closing                             
              if statements.                                           

✖ 8 errors, 0 warnings and 0 suggestions in 2 files.

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidConditions (whitespace-fix)
$ cd /home/aireilly/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidTableBlocks/

┌───── ~/vale-at-red-hat/.vale/fixtures/AsciiDoc/ValidTableBlocks (whitespace-fix)
$ vale .

 testinvalid.adoc
 14:1  error  Unterminated table block found  AsciiDoc.ValidTableBlocks 
              in file.                                                  

✖ 1 error, 0 warnings and 0 suggestions in 2 files.
```