### PR TITLE
demoting "carry out" to a warning

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -61,7 +61,6 @@ cancelled
 cancelling
 canned
 cardreader
-carry out
 case insensitive
 catalogue
 catastrophic error

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -3,6 +3,7 @@ architected
 are updatable
 as well as
 BIOS
+carry out
 click on
 Ctrl-click
 deselect

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -97,7 +97,6 @@ swap:
   cancelling: canceling
   canned: preplanned|preconfigured|predefined
   cardreader: card reader
-  carry out: test|run
   case insensitive: not case-sensitive
   catalogue: catalog
   catastrophic error: unrecoverable error

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -26,6 +26,7 @@ swap:
   bottom right: lower right
   bugfix: bug fix
   can not: cannot
+  carry out: test|run
   click on: click
   deselect: clear
   desired: needed|required


### PR DESCRIPTION
"Carry out" is not an error term. 
https://www.ibm.com/docs/en/ibm-style?topic=word-usage#carry-out