### PR TITLE
Add utilizing to SimpleWords.yml

### DIFF
--- a/.vale/fixtures/RedHat/SimpleWords/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/SimpleWords/testinvalid.adoc
@@ -109,3 +109,4 @@ terminate
 transmit
 utilization
 utilize
+utilizing

--- a/.vale/styles/RedHat/SimpleWords.yml
+++ b/.vale/styles/RedHat/SimpleWords.yml
@@ -118,3 +118,4 @@ swap:
   transmit: send
   utilization: use
   utilize: use
+  utilizing: using


### PR DESCRIPTION
Add utilizing to SimpleWords.yml

"utilize" and "utilization" are included in SimpleWords.yml but I think "utilizing" should also be added. 

Discussed in Vale Slack channel and I agreed to work on a PR.