### PR TITLE
Allow for VT-d, the product is Intel VT-d so should be allowed

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -320,6 +320,7 @@ VM Portal
 vNIC
 vNUMA node
 VPN
+VT-d
 WAN
 WCA
 Web services

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -314,7 +314,7 @@ swap:
   vnuma|VNUMA: vNUMA node
   vpn: VPN
   VS Code|VSCode|VisualStudioCode|VisualStudio Code: Visual Studio Code
-  VT-i|VT: Intel Virtualization Technology
+  VT(?!-d)|VT-i: Intel Virtualization Technology
   wan: WAN
   wca: WCA
   web-UI|webUI: web UI


### PR DESCRIPTION
Fixes incorrect flagging found in ocpdocs-vale-bot: https://github.com/openshift/openshift-docs/pull/72761#discussion_r1532155937