### PR TITLE
Add an em dash rule

### DIFF
--- a/.vale/fixtures/RedHat/EmDash/.vale.ini
+++ b/.vale/fixtures/RedHat/EmDash/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `EmDash` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.EmDash = YES

--- a/.vale/fixtures/RedHat/EmDash/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/EmDash/testinvalid.adoc
@@ -1,0 +1,3 @@
+If you make a mistake—for example, a typographical error—you can correct it easily.
+Reliability, scalability, and availability&mdash;these are priorities for an enterprise system.
+Apply a pattern in one of two ways--select an existing pattern or create a new one.

--- a/.vale/fixtures/RedHat/EmDash/testvalid.adoc
+++ b/.vale/fixtures/RedHat/EmDash/testvalid.adoc
@@ -1,0 +1,1 @@
+If you make a mistake (for example, a typographical error), you can correct it easily.

--- a/.vale/fixtures/RedHat/Hyphens/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Hyphens/testvalid.adoc
@@ -140,7 +140,8 @@ subtab
 superclass
 superobject
 superscript
-timeout|time out
+timeout
+time out
 unavailable
 uncommitted
 unformatted

--- a/.vale/styles/RedHat/EmDash.yml
+++ b/.vale/styles/RedHat/EmDash.yml
@@ -1,0 +1,12 @@
+---
+extends: existence
+ignorecase: true
+level: warning
+scope: raw
+nonword: true
+link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/emdash/
+message: Do not use em dashes. More common punctuation marks, such as commas, parentheses, or a colon, provide the same result.
+tokens:
+  - '—'
+  - '&mdash;'
+  - '(?<=\w+)--(?=\w+)'

--- a/modules/reference-guide/nav.adoc
+++ b/modules/reference-guide/nav.adoc
@@ -8,6 +8,7 @@
 * xref:definitions.adoc[]
 * xref:donotuse.adoc[]
 * xref:ellipses.adoc[]
+* xref:emdashes.adoc[]
 * xref:headingpunctuation.adoc[]
 * xref:headings.adoc[]
 * xref:hyphens.adoc[]

--- a/modules/reference-guide/pages/emdashes.adoc
+++ b/modules/reference-guide/pages/emdashes.adoc
@@ -1,0 +1,12 @@
+:navtitle: Em dashes
+:keywords: reference, rule, em dashes
+
+= Em dashes
+
+Do not use em dashes.
+Use punctuation marks such as commas, parentheses, and colons instead.
+
+.Additional resources
+
+* link:{ibmsg-url-print}[{ibmsg-print} - Em dashes, p.48]
+* link:{ibmsg-url}?topic=punctuation-dashes#em-dashes[{ibmsg} - Em dashes]


### PR DESCRIPTION
Do not use em dashes https://www.ibm.com/docs/en/ibm-style?topic=punctuation-dashes#em-dashes

Catches three forms:

1.  `—`
2. `&mdash;`
3. `(?<=\w)--(?=\w)`

`--` is AsciiDoc markup. See https://asciidoctor.org/docs/asciidoc-writers-guide/#replacements