### PR TITLE
Fix spacing rule 

### DIFF
--- a/.vale/fixtures/RedHat/Spacing/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Spacing/testinvalid.adoc
@@ -1,1 +1,2 @@
 this.  That
+this.That

--- a/.vale/fixtures/RedHat/Spacing/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spacing/testvalid.adoc
@@ -1,1 +1,4 @@
 this. That
+https://rover.redhat.com/apps/
+www.example.com
+docs.microsoft.com

--- a/.vale/styles/RedHat/Spacing.yml
+++ b/.vale/styles/RedHat/Spacing.yml
@@ -6,5 +6,5 @@ message: "Keep one space between words in '%s'."
 nonword: true
 # source: https://docs.microsoft.com/en-us/style-guide/punctuation/periods
 tokens:
-  - "[a-z][.?!] {2,}[A-Z]"
-  - "[a-z][.?!][A-Z]"
+  - '\w+[.?!]\s{2,}[A-Z]\w+'
+  - '\w+[.?!][A-Z]\w+'


### PR DESCRIPTION
In the CI, the spacing rule makes no sense. This update expands the regex to return a meaningful message.
![image](https://github.com/redhat-documentation/vale-at-red-hat/assets/74046732/986dac72-b8f4-4070-a27e-f76d20b5090d)