### PR TITLE
Kubelet Stats Receiver is a new feature and kubelet can use an upper case K in this instance

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -159,6 +159,7 @@ KIE session
 KJAR
 Knowledgebase
 kubelet
+Kubelet Stats Receiver
 Kubernetes
 KVM
 LAN

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -178,7 +178,7 @@ swap:
   kjar|kJAR: KJAR
   knowledgebase: Knowledgebase
   ksession|knowledge session: KIE session
-  Kubelet: kubelet
+  Kubelet(?! Stats Receiver): kubelet
   kubernetes|k8s: Kubernetes
   kvm: KVM
   Lan|lan: LAN


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/73626/files#r1535802857 - example false positive. I don't understand why the error message doesn't suggest replacing with "kubelet" - I can't replicate this locally - but at least this rule won't fire on this product name