### PR TITLE
Removing Azure as an error term 

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -30,7 +30,6 @@ Assertj
 auto-link
 AutoLink
 AWS opt in Region
-Azure
 basic auth
 Basic auth
 Basic Auth

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -176,7 +176,6 @@ Mandrel
 master-slave group
 MicroProfile
 Microsoft
-Microsoft Azure
 Microsoft Azure Cross-Platform Command-Line Interface
 Microsoft Azure On-Demand Marketplace
 Microsoft Azure portal

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -11,7 +11,6 @@ swap:
   "(?<!.-)javadocs?": Javadoc|API documentation|Java API documentation
   "(?<!/)var": VAR
   "(?<!Business )Resource Planner|(?<!Business Resource )Planner": Business Resource Planner
-  "(?<!Microsoft )Azure(?! Red Hat OpenShift)": Microsoft Azure
   "(?<!Microsoft Azure )On-Demand Marketplace": Microsoft Azure On-Demand Marketplace
   "(?<!Red Hat )Customer Portal": Red Hat Customer Portal
   "(?<!Red Hat )JBoss Enterprise Application Platform": Red Hat JBoss Enterprise Application Platform


### PR DESCRIPTION
The SSG allows Azure as a term if it's already been defined previously as Microsoft Azure. So perhaps a more complex rule is required instead. 

Also too many errors on Azure product names. 