### PR TITLE
Excluding term that is a valid OCP operator

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -151,6 +151,7 @@ JVM
 kernel
 kernel space
 Kernel-based Virtual Machine
+Kernel Module Management
 keystore
 Kickstart
 KIE

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -23,7 +23,7 @@ swap:
   "DM(?![ -]Multipath)|directory manager": Directory Manager
   "JBoss Broker|Red Hat Broker|The AMQ Broker": AMQ Broker
   "JBoss Console|Red Hat Console": AMQ Console
-  "Kernel(?!-based Virtual Machine)": kernel
+  "Kernel(?!-based Virtual Machine| Module Management)": kernel
   "OCM|(?<!Red Hat OpenShift )Cluster Manager|(?<!Red Hat )OpenShift Cluster Manager|the OpenShift Cluster Manager": Red Hat OpenShift Cluster Manager
   "OD": Red Hat OpenShift Dedicated
   "sub version|(?<!Apache )Subversion": sub-version


### PR DESCRIPTION
Adding an exception for the term Kernel Module Management as this is a valid OCP operator. 

See false positive here: https://github.com/openshift/openshift-docs/pull/74713#discussion_r1567479450

