### PR TITLE
ci(lint): add shell linter - Differential ShellCheck

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,27 @@
+name: Differential ShellCheck
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/generate-vale-rule-tests.sh
+++ b/tools/generate-vale-rule-tests.sh
@@ -15,7 +15,7 @@ set -e
 for RULE in $(find .vale/styles/RedHat/ -name '*.yml' | cut -d/ -f 4 | cut -d. -f1 | sort)
 do
     RULETESTDIR=".vale/fixtures/RedHat/$RULE"
-    test -d $RULETESTDIR || mkdir "$RULETESTDIR"
+    test -d "$RULETESTDIR" || mkdir "$RULETESTDIR"
     touch "$RULETESTDIR/testinvalid.adoc"
     touch "$RULETESTDIR/testvalid.adoc"
     cat <<EOF > "$RULETESTDIR/.vale.ini"


### PR DESCRIPTION
## Description

Addition of a new job in CI workflow that scans all shell scripts in the repo using ShellCheck and reports only newly added defects.

Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on shell scripts changed via PR and reports results directly in PR.

It produces reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the `Files Changed` tab, please see below.

Documentation is available at [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme).

## Screenshots

![image](https://github.com/debezium/debezium/assets/2879818/e0f16691-907f-486d-a20e-4b569322e860)

![image](https://github.com/debezium/debezium/assets/2879818/cc842adf-04b6-425c-ae7d-c39b8dffa09b)
