### PR TITLE
Fix RedHat DoNotUseTerms validation issues for Red{nbsp}Hat

### DIFF
--- a/.vale/fixtures/RedHat/DoNotUseTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/DoNotUseTerms/testinvalid.adoc
@@ -21,3 +21,6 @@ respectively
 time-tested
 debuggable
 and/or
+Red flag
+red band
+red-thing

--- a/.vale/fixtures/RedHat/DoNotUseTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/DoNotUseTerms/testvalid.adoc
@@ -1,2 +1,5 @@
 hash sign
 ACK flag
+Red{nbsp}Hat
+Red Hat
+red-hat

--- a/.vale/styles/RedHat/DoNotUseTerms.yml
+++ b/.vale/styles/RedHat/DoNotUseTerms.yml
@@ -4,6 +4,7 @@ ignorecase: true
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/donotuse/
 message: "%s"
+scope: raw
 swap:
   # Start each error message with "Do not use ..."
   # Error messages must be single quoted.
@@ -12,11 +13,11 @@ swap:
   'out of the box|out-of-the-box': 'Do not use "out of the box" or "out-of-the-box". Use text that is suitable for the context and the noun to which this adjective applies.'
   and/or: 'Do not use "and/or". Depending on the context, use one of the following constructions: a and b, a or b, or a, b, or both.'
   basically: 'Do not use "basically". "Basically" is another term for "in principle" or "fundamentally".'
-  congratulations: 'Do not use "congratulations" in technical information."'
+  congratulations: 'Do not use "con gratulations" in technical information."'
   debuggable: 'Do not use "debuggable". Rephrase the sentence to use the verb or noun debug. For example, change rebuild the debuggable version to rebuild the version that can be debugged.'
   foo: 'Do not use "foo". This term is technical jargon in code and as shorthand for fubar, an acronym of profanity in code.'
   fubar: 'Do not use "fubar". This term is an acronym of a profanity that is sometimes used by developers in code.'
-  \bred\b(?!-? *hat)|orange|yellow|green|blue|indigo|violet: 'Do not use colors to describe something unless it is also described non-visually, for example, with the name of the item.'
+  \bred\b(?!-? *hat|{nbsp})|orange|yellow|green|blue|indigo|violet: 'Do not use colors to describe something unless it is also described non-visually, for example, with the name of the item.'
   kerberize|kerberized: 'Do not use "kerberize" to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled", or rewrite the sentence.'
   native interface: 'Do not use "native interface" to refer to the command line interface for the JBoss EAP management tool.'
   overhead: 'Do not use "overhead". Use terminology that is more specific. For example, write "running large queries can increase processor usage".'


### PR DESCRIPTION
Updated the regex to not match `Red{nbsp}Hat`.

Currently it shows a suggestion:
```
Do not use colors to describe something unless it is also described non-visually, 
for example, with the name of the item.
```