### PR TITLE
Add guidance re: the Red Hat Hybrid Cloud Console

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -75,6 +75,7 @@ classic mode
 Classless Inter-domain Routing
 Classless Interdomain Routing
 CloudForms Management Engine
+Cloud Console 
 Cluster Manager
 command prompt
 Compared to yaml, JSON has way more curly braces.
@@ -180,11 +181,13 @@ Grub
 Gtk
 gtk
 GUI editor
+HCC
 hot rod
 HotRod
 hotrod
 HP Proliant
 HTTP interface
+Hybrid Cloud Console 
 hyper-threading
 hyperthreading
 Hyperviser
@@ -395,6 +398,7 @@ RAW
 Red Boot
 Red Hat Broker
 Red Hat Console
+Red Hat Hybrid Cloud Console
 Red Hat Interconnect
 Red Hat JBoss Data Grid
 Red Hat JBoss EAP
@@ -490,6 +494,13 @@ Technology preview
 technology preview
 The AMQ Broker
 The Operator Lifecycle Manager
+the Cloud Console
+The Cloud Console 
+the HCC 
+The HCC
+the RH HCC
+The RH HCC 
+Tolapai
 ttl
 uid
 UltraSparc

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -301,6 +301,10 @@ T-BC
 Technology Preview
 Temurin
 The .NET framework
+the Hybrid Cloud Console
+The Hybrid Cloud Console
+the Red Hat Hybrid Cloud Console
+The Red Hat Hybrid Cloud Console
 TLS handshake
 TTL
 UID

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -53,6 +53,7 @@ swap:
   'Red\sHat\sVirtualization\sHypervisor|RHV\sHost|RHV-H': Red Hat Virtualization Host
   'RHVM|RHV-M|RHV\sManager': Red Hat Virtualization Manager
   'self-hosted\sengine\svirtual\smachine|engine\sVM': Manager virtual machine
+  "(?<![tT]he |[tT]he Red Hat )Hybrid Cloud Console|(?<![tT]he )Red Hat Hybrid Cloud Console|(?<![tT]he |Red Hat |Hybrid )Cloud Console|[tT]he Cloud Console|HCC|[tT]he HCC|[tT]he RH HCC": The (or the) Red Hat Hybrid Cloud Console (first instance)|The (or the) Hybrid Cloud Console
   (?<!Ansible )Playbook: playbook
   Ansible playbook: Ansible Playbook
   Ansible rulebook: Ansible Rulebook


### PR DESCRIPTION
Added:
- suggestion to use "the" preceding Red Hat Hybrid Cloud Console or Hybrid Cloud Console
- suggestions to properly refer to the Red Hat Hybrid Cloud Console
- additional suggested first mention rule