### PR TITLE
Tweak Red Hat colours rule

### DIFF
--- a/.vale/fixtures/RedHat/DoNotUseTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/DoNotUseTerms/testvalid.adoc
@@ -1,2 +1,6 @@
 hash sign
 ACK flag
+Red Hat
+Red{nbsp}Hat
+redhat
+red-hat

--- a/.vale/styles/RedHat/DoNotUseTerms.yml
+++ b/.vale/styles/RedHat/DoNotUseTerms.yml
@@ -1,6 +1,6 @@
 ---
 extends: substitution
-ignorecase: true
+ignorecase: false
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/donotuseterms/
 message: "%s"


### PR DESCRIPTION
Builds on https://github.com/redhat-documentation/vale-at-red-hat/pull/780

`Red Hat` and `Red{nbsp}Hat` should not raise a Vale error.