### PR TITLE
Added some phrasal verbs to avoid

### DIFF
--- a/.vale/fixtures/RedHat/SimpleWords/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/SimpleWords/testinvalid.adoc
@@ -1,6 +1,5 @@
 absent
 abundance
-accelerate
 accentuate
 accompany
 accomplish

--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -3,6 +3,8 @@ architected
 are updatable
 as well as
 BIOS
+call up
+carry on
 carry out
 click on
 Ctrl-click
@@ -16,6 +18,7 @@ downgrade
 entitlement
 etc
 execute
+find out
 hamburger
 he
 host name
@@ -42,12 +45,15 @@ opt into
 opting into
 preload
 preloaded
+print out
 right double-click
 sane
 she
 shift-click
 spawn
 start up
+speed up
+speeds up
 switch on
 tap on
 tarball

--- a/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
@@ -1,4 +1,5 @@
 accurate
+accelerate
 after
 and
 and so on
@@ -11,6 +12,7 @@ colocation
 delete
 deleted
 designed
+discover
 end
 end
 ensure
@@ -44,6 +46,7 @@ open
 plugin
 preinstall
 preinstalled
+print
 process
 repository
 roll back

--- a/.vale/styles/RedHat/SimpleWords.yml
+++ b/.vale/styles/RedHat/SimpleWords.yml
@@ -12,7 +12,6 @@ swap:
   "objective(?! C?)": aim|goal
   absent: none|not here
   abundance: plenty
-  accelerate: speed up
   accentuate: stress
   accompany: go with
   accomplish: carry out|do

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -26,7 +26,9 @@ swap:
   bottom left: lower left
   bottom right: lower right
   bugfix: bug fix
+  call up: call
   can not: cannot
+  carry on: continue
   carry out: test|run
   click on: click
   deselect: clear
@@ -37,6 +39,7 @@ swap:
   downgrade: upgrade|fallback|fall back|rollback|roll back
   entitlement: repository|subscription
   execute: run|issue|start|enter
+  find out: discover
   hamburger|kebab menu|kebab: more options icon|options icon
   he|she: you
   host name: hostname
@@ -54,11 +57,14 @@ swap:
   opt into|opting into: opt in
   preload: preinstall
   preloaded: preinstalled
+  print out: print
   right double-click: double right-click
   sane: accurate|valid|verified
   shift-click: press Shift and click
   spawn: create
   start up: start
+  speed up: accelerate
+  speeds up: accelerates
   switch on: turn on
   tap on: tap
   tarball: tar file


### PR DESCRIPTION
I was going through Applying the IBM Style Guide in Writing Product Documentation and checked to see if out rules had that info covered. 

- Also, we recommend using `accelerate` instead of speed up:
![image](https://github.com/redhat-documentation/vale-at-red-hat/assets/23069445/2dded0a1-2b20-458e-9b01-eaad223bc759)
