### PR TITLE
Add exceptions to the Passive voice rule

### DIFF
--- a/.vale/fixtures/RedHat/PassiveVoice/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PassiveVoice/testvalid.adoc
@@ -1,4 +1,3 @@
-It decided
 It awoken
 It beat
 It become
@@ -31,6 +30,7 @@ It cost
 It crept
 It cut
 It dealt
+It decided
 It dived
 It done
 It drawn
@@ -65,6 +65,11 @@ It hidden
 It hit
 It hung
 It hurt
+It is deprecated
+It is imported
+It is supported
+It is tested
+It is trusted
 It kept
 It knelt
 It knit

--- a/.vale/styles/RedHat/PassiveVoice.yml
+++ b/.vale/styles/RedHat/PassiveVoice.yml
@@ -184,3 +184,9 @@ tokens:
   - woven
   - written
   - wrung
+exceptions:
+  - deprecated
+  - imported
+  - supported
+  - tested
+  - trusted


### PR DESCRIPTION
```
exceptions:
  - deprecated
  - required
  - imported
  - supported
  - trusted
  - tested
```

~removed~ ~required~

Examples of the above terms in passive usage (lifted from openshift-docs):

1. Service Catalog is deprecated on {product-title} 4 and later.
2. When you create the virtual machine (VM), the data volume with the {object} is imported into persistent storage.
3. This credentials strategy is supported for only new {product-title} clusters and must be configured during installation.
4. Inject the CA bundle that is trusted by {product-title} into the config map by running the following command:
5. The default configuration used by DVM is tested in various environments.

~After the associated credential is removed, it can be deleted or deactivated on the underlying cloud.~

~If you deploy using infrastructure that you manage no additional configuration is required.~

Update: I removed "removed" and "required" from the list since these seems to me to be "primary" verbs that we do want to rewrite in active form for the most part. 