### PR TITLE
Update GitLab Vale code quality reports

### DIFF
--- a/modules/user-guide/examples/gitlab-ci.yml
+++ b/modules/user-guide/examples/gitlab-ci.yml
@@ -1,19 +1,32 @@
+image: node:16-alpine
+
+stages:
+  - test
+
 code_quality:
+  stage: test
   image:
     name: jdkato/vale:latest
     entrypoint: [""]
   tags: [shared]
   before_script:
-    - apk update && apk add git
-    - vale sync # pull down VRH rules package specified in vale.ini
+    - apk update && apk add git jq
+    - vale sync # Pull down VRH rules package specified in vale.ini
   script:
-    # list of updated/modified *.adoc files
-    - FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=d "*.adoc")
-    # clean out conditions for wider vale coverage
+    # List of updated/modified *.adoc files
+    - FILES=$(find . -type f -name "*.adoc")
+    # Clean out conditions for wider vale coverage
     - sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' ${FILES}
-    # use a template to rearrange the vale JSON output
-    # run vale with `--no-exit` to pass the build with errors
-    - vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output="$(pwd)/vale-json.tmpl" | sed "s/CI_COMMIT_SHA/$CI_COMMIT_SHA/g" > gl-code-quality-report.json
+    # Use a template to rearrange the vale JSON output
+    # Run vale with --no-exit to pass the build with errors
+    - vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output="$(pwd)/vale-json.tmpl" | jq . > gl-code-quality-report.json
+    - echo $CI_DEFAULT_BRANCH
   artifacts:
     reports:
       codequality: gl-code-quality-report.json
+  rules:
+    - if: $CODE_QUALITY_DISABLED
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" # Run code quality job in merge request pipelines
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH # Run code quality job in pipelines on the default branch (but not in other branch pipelines)
+    - if: $CI_COMMIT_TAG # Run code quality job in pipelines for tags

--- a/modules/user-guide/examples/vale-json.tmpl
+++ b/modules/user-guide/examples/vale-json.tmpl
@@ -1,4 +1,4 @@
-{{- /* Modify Vale's output https://docs.errata.ai/vale/cli#--output */ -}}
+{{- /* Modify Vale output https://docs.errata.ai/vale/cli#--output */ -}}
 
 {{- /* Keep track of our various counts */ -}}
 
@@ -10,48 +10,51 @@
 {{- /* Range over the linted files */ -}}
 
 [
+{{- $first := true -}}
 {{- range $jdx, $file := .Files -}}
+  {{- $f = add1 $f -}}
+  {{- $path := $file.Path -}}
 
-{{- $f = add1 $f -}}
-{{- $path := .Path -}}
+  {{- /* Range over the file's alerts */ -}}
+  {{- range $idx, $a := $file.Alerts -}}
+    {{- if not $first -}},{{- end -}}
+    {{- $first = false -}}
 
-{{- /* Range over the file's alerts */ -}}
+    {{- $error := "" -}}
+    {{- if eq $a.Severity "error" -}}
+      {{- $error = "critical" -}}
+      {{- $e = add1 $e -}}
+    {{- else if eq $a.Severity "warning" -}}
+      {{- $error = "major" -}}
+      {{- $w = add1 $w -}}
+    {{- else -}}
+      {{- $error = "minor" -}}
+      {{- $s = add1 $s -}}
+    {{- end}}
 
-{{- if $jdx -}},{{- end -}}
-{{- range $idx, $a := .Alerts -}}
+    {{- /* Variables setup */ -}}
 
-{{- $error := "" -}}
-{{- if eq .Severity "error" -}}
-    {{- $error = "critical" -}}
-    {{- $e = add1 $e  -}}
-{{- else if eq .Severity "warning" -}}
-    {{- $error = "major" -}}
-    {{- $w = add1 $w -}}
-{{- else -}}
-    {{- $error = "minor" -}}
-    {{- $s = add1 $s -}}
-{{- end}}
+    {{- $loc := printf "%d" $a.Line -}}
+    {{- $check := printf "%s" $a.Check -}}
+    {{- $message := printf "%s" $a.Message -}}
 
-{{- /* Variables setup */ -}}
+    {{- /* Compute the Base64 encoded fingerprint string */ -}}
+    {{- $hashInput := printf "%s:%s:%s" $path $loc $message -}}
+    {{- $Base64Encoded := b64enc $hashInput -}}
 
-{{- $loc := printf "%d" .Line -}}
-{{- $check := printf "%s" .Check -}}
-{{- $message := printf "%s" .Message -}}
-{{- if $idx -}},{{- end -}}
-
-{{- /* Output */ -}}
-
-  {
-    "description": "{{$check}}: {{ $message }}",
-    "fingerprint": "CI_COMMIT_SHA",
-    "severity": "{{ $error }}",
-    "location": {
-      "path": "{{ $path }}",
-      "lines": {
-        "begin": {{ $loc }}
+    {{- /* Output */ -}}
+    {
+      "description": "{{$check}}: {{ $message }}",
+      "check_name": "vale-error-report",
+      "fingerprint": "{{ $Base64Encoded }}",
+      "severity": "{{ $error }}",
+      "location": {
+        "path": "{{ $path }}",
+        "lines": {
+          "begin": {{ $loc }}
+        }
       }
     }
-  }
-{{end -}}
-{{end -}}
+  {{- end -}}
+{{- end -}}
 ]

--- a/modules/user-guide/pages/gitlab-code-quality-reports.adoc
+++ b/modules/user-guide/pages/gitlab-code-quality-reports.adoc
@@ -62,4 +62,4 @@ Once merged, a code quality pipeline runs for every new commit added in a PR. Ac
 
 [role="_additional-resources"]
 .Additional resources
-* For more details on GitLab's Code Quality feature, see the link:https://docs.gitlab.com/ee/ci/testing/code_quality.html[GitLab Docs].
+* For more details on GitLab's Code Quality feature, see the link:https://docs.gitlab.com/ee/ci/testing/code_quality.html[Code Quality].

--- a/modules/user-guide/pages/introduction.adoc
+++ b/modules/user-guide/pages/introduction.adoc
@@ -10,7 +10,8 @@
 
 Vale is a command-line tool that allows you to check your writing for grammar and spelling errors against a set of style rules. It's open source, fast, and highly customizable.
 
-video::745894696[vimeo,align="left",title="A brief non-technical introduction"]
+//video link is failing htmltest
+//video::745894696[vimeo,align="left",title="A brief non-technical introduction"]
 
 [id="con_the-benefits-of-using-vale"]
 == How does Vale help you improve your content?


### PR DESCRIPTION
Previously, GitLab Vale code quality reports procedure was broken. This update fixes the docs and examples.

A complete working example is provided here: https://gitlab.cee.redhat.com/aireilly/asciidoc-vale-ci-demo/-/merge_requests/35