### PR TITLE
upgrades attribute sub rule to error

### DIFF
--- a/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
@@ -1,6 +1,6 @@
 ---
 extends: substitution
-level: suggestion
+level: error
 ignorecase: false
 message: "Use the AsciiDoc attribute '%s' rather than the plain text product term '%s', unless your use case is an exception."
 link: https://github.com/openshift/openshift-docs/blob/main/_attributes/common-attributes.adoc


### PR DESCRIPTION
This change will cause the Vale bot in the OCP docs GH repo to leave comments when an attribute should be substituted. 

Note: this applies _only_ to attributes in the `SuggestAttribute.yml` file, not _all_ possible attributes to substitute. The intent is to ensure that some critical ones are noticed and used.

Per Shauna's observation, I have asked for input on clashes specifically for [MicroShift](https://redhat-internal.slack.com/archives/C85JYPHL3/p1719586566920439?thread_ts=1719585899.572939&cid=C85JYPHL3) and [SD docs](https://redhat-internal.slack.com/archives/C0308P3FC7R/p1719594945553029) use