### PR TITLE
Add vCenter to Spelling rule

### DIFF
--- a/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
+++ b/.vale/fixtures/RedHat/PascalCamelCase/testvalid.adoc
@@ -175,6 +175,7 @@ UltraSPARC
 USBGuard
 UUIDs
 vCPUs
+vCenter
 vDisk
 vHost
 VMs

--- a/.vale/styles/RedHat/PascalCamelCase.yml
+++ b/.vale/styles/RedHat/PascalCamelCase.yml
@@ -173,6 +173,7 @@ exceptions:
   - TypeScript
   - UltraSPARC
   - USBGuard
+  - vCenter
   - vDisk
   - vHost
   - VMware

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -496,6 +496,7 @@ filters:
   - USBGuard
   - Vale
   - Valgrind
+  - vCenter
   - vDisk
   - Velero
   - Vert.x


### PR DESCRIPTION
Adding 'vCenter' to spelling rule