### PR TITLE
vCentre datacenter is an accepted term in OCP's VMWare implementation

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testvalid.adoc
@@ -631,6 +631,7 @@ twistie
 type
 typing error
 typographical error
+vCenter datacenter
 un-customized
 unavailable
 unconfigure

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -142,7 +142,7 @@ swap:
   cyber threat: cyberthreat
   cyberresilience: cyber resilience
   data base: database
-  datacenter|data-center|data centre|datacentre: data center
+  (?<!vCenter )datacenter|data-center|data centre|datacentre: data center
   datafile: data file
   dataflow: data flow
   datamart: data mart


### PR DESCRIPTION
https://docs.openshift.com/container-platform/4.16/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements_ipi-vsphere-installation-reqs

vCenter datacenter is valid here