### PR TITLE
Update SequentialNumberedCallouts.yml to ignore lines with conditional blocks

### DIFF
--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
@@ -29,3 +29,20 @@ get '/hi' do <4>
 ----
 <1> Test
 <3> Test
+
+[source,terminal]
+----
+$ helm install -n stackrox --create-namespace \
+    stackrox-secured-cluster-services rhacs/secured-cluster-services \
+    -f <path_to_cluster_init_bundle.yaml> \// <1>
+    -f <path_to_pull_secret.yaml> \// <2>
+    --set clusterName=<name_of_the_secured_cluster> \
+    --set centralEndpoint=<endpoint_of_central_service> <3>
+    --set imagePullSecrets.username=<your redhat.com username> \
+    --set imagePullSecrets.password=<your redhat.com password>
+----
+<1> Use the `-f` option to specify the path for the init bundle.
+<2> Use the -f option to specify the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
+<3> Specify the address and port number for Central. For example, `acs.domain.com:443`.
+<3> Enter the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the ACS instance you created.
+

--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
@@ -19,7 +19,29 @@ require 'sinatra' <1>
 get '/hi' do <1>
   "Hello World!"
 end
-key: value <2> 
+key: value <2>
 ----
 <1> Library import
 <2> URL mapping
+
+[source,terminal]
+----
+$ helm install -n stackrox --create-namespace \
+    stackrox-secured-cluster-services rhacs/secured-cluster-services \
+    -f <path_to_cluster_init_bundle.yaml> \// <1>
+    -f <path_to_pull_secret.yaml> \// <2>
+    --set clusterName=<name_of_the_secured_cluster> \
+    --set centralEndpoint=<endpoint_of_central_service> <3>
+    --set imagePullSecrets.username=<your redhat.com username> \//<4>
+    --set imagePullSecrets.password=<your redhat.com password>//<5>
+----
+<1> Use the `-f` option to specify the path for the init bundle.
+<2> Use the -f option to specify the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
+ifndef::cloud-svc[]
+<3> Specify the address and port number for Central. For example, `acs.domain.com:443`.
+endif::[]
+ifdef::cloud-svc[]
+<3> Enter the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the ACS instance you created.
+endif::[]
+<4> Include the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
+<5> Include the password for your pull secret for Red{nbsp}Hat Container Registry authentication.

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -16,16 +16,32 @@ script: |
   prev_num := 0
   callout_regex := "^<(\\d+)>"
   listingblock_delim_regex := "^-{4,}$"
+  ifdef_regex := "^ifdef::"
+  ifndef_regex := "^ifndef::"
+  endif_regex := "^endif::"
+
+  in_conditional := false
 
   for line in text.split(scope, "\n") {
     // trim trailing whitespace
     line = text.trim_space(line)
+
+    // check if we're entering a conditional block
+    if text.re_match(ifdef_regex, line) or text.re_match(ifndef_regex, line) {
+      in_conditional := true
+    }
+
+    // check if we're exiting a conditional block
+    if text.re_match(endif_regex, line) {
+      in_conditional := false
+    }
+
     //reset count if we hit a listing block delimiter
     if text.re_match(listingblock_delim_regex, line) {
       prev_num = 0
     }
 
-    if text.re_match(callout_regex, line) {
+    if not in_conditional and text.re_match(callout_regex, line) {
       callout := text.re_find("<(\\d+)>", line)
       for key, value in callout {
         //trim angle brackets from string

--- a/tengo-rule-scripts/SequentialNumberedCallouts.tengo
+++ b/tengo-rule-scripts/SequentialNumberedCallouts.tengo
@@ -1,6 +1,6 @@
 /*
     Tengo Language
-    Checks that callouts outside the listing block are sequential 
+    Checks that callouts outside the listing block are sequential
     $ tengo SequentialNumberedCallouts.tengo <asciidoc_file_to_validate>
 */
 
@@ -20,16 +20,32 @@ scope += "\n"
 prev_num := 0
 callout_regex := "^<(\\d+)>"
 listingblock_delim_regex := "^-{4,}$"
+ifdef_regex := "^ifdef::"
+ifndef_regex := "^ifndef::"
+endif_regex := "^endif::"
+
+in_conditional := false
 
 for line in text.split(scope, "\n") {
   // trim trailing whitespace
   line = text.trim_space(line)
+
+  // check if we're entering a conditional block
+  if text.re_match(ifdef_regex, line) or text.re_match(ifndef_regex, line) {
+    in_conditional := true
+  }
+
+  // check if we're exiting a conditional block
+  if text.re_match(endif_regex, line) {
+    in_conditional := false
+  }
+
   //reset count if we hit a listing block delimiter
   if text.re_match(listingblock_delim_regex, line) {
     prev_num = 0
   }
 
-  if text.re_match(callout_regex, line) {
+  if not in_conditional and text.re_match(callout_regex, line) {
     callout := text.re_find("<(\\d+)>", line)
     for key, value in callout {
       //trim angle brackets from string
@@ -51,5 +67,5 @@ for line in text.split(scope, "\n") {
 if len(matches) == 0 {
   fmt.println("Callouts are sequential")
 } else {
-  fmt.println(matches) 
+  fmt.println(matches)
 }


### PR DESCRIPTION
Modified the script to ignore lines with conditional blocks.

The current script gives a false positive for callouts with the same number inside the conditional directives (`ifdef` and `ifndef`). 