### PR TITLE
Correct AsciiDoc.ImageContainsAltText criteria

### DIFF
--- a/.vale/styles/AsciiDoc/ImageContainsAltText.yml
+++ b/.vale/styles/AsciiDoc/ImageContainsAltText.yml
@@ -5,5 +5,4 @@ level: warning
 link: https://redhat-documentation.github.io/supplementary-style-guide/#cloud-services-images
 message: "Image is missing accessibility alt tags."
 raw:
-  - 'image::.*\[\]'
-  - 'image:.*\[\]'
+  - 'image::?.*\[\]'


### PR DESCRIPTION
If there are multiple entries in the raw array, they are concatenated into one large regular expression.  In this case, this meant that we were searching for the regular expression `image::.*\[\]image:.*\[\]`, which doesn't find images without alt text.

In this commit, we use a single regular expression that will match both cases: image with one colon, and image with two colons.

closes #829 