### PR TITLE
Update Satellite terms

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -398,8 +398,6 @@ Red Hat Console
 Red Hat Interconnect
 Red Hat JBoss Data Grid
 Red Hat JBoss EAP
-Red Hat Network Satellite server
-Red Hat Proxy
 Red Hat satellite
 Red Hat Satellite Capsule server
 Red Hat Satellite server
@@ -481,7 +479,7 @@ StartX
 STI
 SU
 sub version
-Subscription manifest
+Subscription Manifest
 Sys V
 system d
 system D

--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testvalid.adoc
@@ -244,8 +244,6 @@ Red Hat Fuse Online
 Red Hat JBoss BPM Suite
 Red Hat JBoss BRMS
 Red Hat JBoss Enterprise Application Platform
-Red Hat Network Proxy Server
-Red Hat Network Satellite Server
 Red Hat OpenShift Cluster Manager
 Red Hat OpenShift Container Platform
 Red Hat OpenShift Data Foundation
@@ -294,7 +292,7 @@ StarOffice
 STARTTLS
 startx
 su
-Subscription Manifest
+subscription manifest
 Syndesis
 systemd
 SysV

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -243,8 +243,6 @@ swap:
   RAW: raw
   Red Hat JBoss Data Grid|JDG: Red Hat Data Grid
   Red Hat JBoss EAP: Red Hat JBoss Enterprise Application Platform
-  Red Hat Network Satellite server: Red Hat Network Satellite Server
-  Red Hat Proxy: Red Hat Network Proxy Server
   Red Hat Satellite Capsule server: Red Hat Satellite Capsule Server
   Red Hat Satellite server: Red Hat Satellite Server
   Red Hat satellite: Red Hat Satellite
@@ -289,7 +287,7 @@ swap:
   StartX: startx
   STI|source to image: Source-to-Image (S2I)
   SU: su
-  Subscription manifest: Subscription Manifest
+  Subscription Manifest: subscription manifest
   Sys V|System V: SysV
   system D|system D|SystemD|system d: systemd
   Technology preview|technology preview: Technology Preview


### PR DESCRIPTION
Removed "Red Hat Network Satellite Server" and "Red Hat Network Proxy Server" because these terms are obsolete.

Updated "Subscription manifest" because Satellite no longer capitalizes this term. (Maybe it should be just "Manifest: manifest"?)