### PR TITLE
Add key/value as exception to Slash rule

### DIFF
--- a/.vale/fixtures/RedHat/Slash/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Slash/testvalid.adoc
@@ -8,6 +8,7 @@ client/server
 I/O
 input/output
 Input/Output
+key/value
 N/A
 read/write
 SSL/TLS


### PR DESCRIPTION
I did not find any guidance about using "key/value pairs" in ISG or RHSSG, so I thought it would be good to add as an exception.