### PR TITLE
Add "re-register" and "re-sign" to hyphens rule

### DIFF
--- a/.vale/fixtures/RedHat/Hyphens/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/Hyphens/testinvalid.adoc
@@ -175,6 +175,7 @@ pseudo-text
 re-direct
 re-edit
 re-examine
+re-register
 re-synchronize
 recreate
 reenable

--- a/.vale/fixtures/RedHat/Hyphens/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Hyphens/testvalid.adoc
@@ -121,9 +121,11 @@ pseudotext
 redirect
 reedit
 reexamine
+reregister
 resynchronize
 re-create
 re-enable
+re-sign
 semicolon
 semiconductor
 subaddress

--- a/.vale/styles/RedHat/Hyphens.yml
+++ b/.vale/styles/RedHat/Hyphens.yml
@@ -190,6 +190,7 @@ swap:
   re-direct: redirect
   re-edit: reedit
   re-examine: reexamine
+  re-register: reregister
   re-synchronize: resynchronize
   recreate: re-create
   reenable: re-enable


### PR DESCRIPTION
Add "re-register" (error) and "re-sign" (valid) to the hyphens rule.