### PR TITLE
Remove 'bare metal' test lines

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -30,25 +30,7 @@ back slash
 backside
 backwards compatible
 barcode
-bare metal clusters
-bare metal compute
-bare metal configuration
-bare metal control
-bare metal environment
-bare metal equipment
-bare metal event
-bare metal hardware
-bare metal host
-bare metal infrastructure
-bare metal installation
-bare metal installer
-bare metal machine
-bare metal media
-bare metal node
-bare metal provisioning
-bare metal server
-bare metal worker
-Install on bare-metal.
+bare-metal.
 best of breed
 Bidi
 Big Blue


### PR DESCRIPTION
Deleting the 'bare metal' lines in the TermsErrors `testinvalid.adoc` file so that the rules validation check does not fail.