### PR TITLE
Put back bare metal rule

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -30,6 +30,25 @@ back slash
 backside
 backwards compatible
 barcode
+bare metal clusters
+bare metal compute
+bare metal configuration
+bare metal control
+bare metal environment
+bare metal equipment
+bare metal event
+bare metal hardware
+bare metal host
+bare metal infrastructure
+bare metal installation
+bare metal installer
+bare metal machine
+bare metal media
+bare metal node
+bare metal provisioning
+bare metal server
+bare metal worker
+Install on bare-metal.
 bare-metal.
 best of breed
 Bidi

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -19,7 +19,7 @@ swap:
   "(?<!Mozilla )Thunderbird": Mozilla Thunderbird
   "(?<!pseudo-)ops": operations
   "(?<!self-)hosted engine|hosted-engine": self-hosted engine
-  #"bare metal( clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare-metal $1
+  "bare metal( clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare-metal $1
   "bare-metal(?! clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal
   "[bB]asic [aA]uth": Basic HTTP authentication|Basic authentication
   "a lot(?: of)?": many|much


### PR DESCRIPTION
We can put back the bare metal rule since the quay.io/rhdevdocs/devspaces-documentation container was updated.

```cmd
podman run quay.io/rhdevdocs/devspaces-documentation vale -v
vale version 3.7.0
```