### PR TITLE
Remove dupe rule for cannot

### DIFF
--- a/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsSuggestions/testinvalid.adoc
@@ -5,7 +5,6 @@ below
 bottom left
 bottom right
 bugfix
-can not
 choose
 componentization
 componentize

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -28,7 +28,6 @@ swap:
   bottom left: lower left
   bottom right: lower right
   bugfix: bug fix
-  can not: cannot
   choose: select
   componentization: component-based development|component model|component architecture|shared components
   componentize: develop components|divide into components|re-engineer into reusable software components


### PR DESCRIPTION
"Can not" is a do not use term in the ISG

https://www.ibm.com/docs/en/ibm-style?topic=word-usage#can-not

