### PR TITLE
Adding telco spelling exception

### DIFF
--- a/.vale/fixtures/RedHat/Spelling/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Spelling/testvalid.adoc
@@ -586,6 +586,7 @@ Templated
 Temurin
 Tensorflow
 Texinfo
+Telco
 Theia
 time frame
 timeout|time out

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -219,6 +219,7 @@ filters:
   - "[sS]ysctl"
   - "[sS]yslog"
   - "[sS]ystemd"
+  - "[tT]elco"
   - "[tT]emplated"
   - "[tT]heia"
   - "[tT]olerations"


### PR DESCRIPTION
Telco is a valid term per ISG: https://www.ibm.com/docs/en/ibm-style?topic=word-usage#telco