### PR TITLE
Implementing a Flesch–Kincaid grade level rule

### DIFF
--- a/.vale/fixtures/RedHat/ReadabilityGrade/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/ReadabilityGrade/testinvalid.adoc
@@ -1,0 +1,1 @@
+Tune and configure the cluster host firmware and various other cluster configuration settings.

--- a/.vale/fixtures/RedHat/ReadabilityGrade/testvalid.adoc
+++ b/.vale/fixtures/RedHat/ReadabilityGrade/testvalid.adoc
@@ -1,0 +1,1 @@
+Tune and configure the cluster host firmware.

--- a/.vale/styles/RedHat/ReadabilityGrade.yml
+++ b/.vale/styles/RedHat/ReadabilityGrade.yml
@@ -1,12 +1,9 @@
 ---
 extends: readability
-grade: 21
-level: suggestion
+grade: 9
+message: "Simplify your language. The calculated Flesch–Kincaid grade level of %s is above the recommended reading grade level of 9."
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/readabilitygrade/
-message: "Grade level ('%s') too high."
+level: suggestion
 metrics:
-  - Automated Readability
-  - Coleman-Liau
   - Flesch-Kincaid
-  - Gunning Fog
-  - SMOG
+

--- a/modules/reference-guide/pages/readabilitygrade.adoc
+++ b/modules/reference-guide/pages/readabilitygrade.adoc
@@ -3,9 +3,10 @@
 
 = Readability grade
 
-Grade level too high.
+Try to write paragraphs that have a calculated Flesch–Kincaid grade level below the recommended value of 9.
 
 .Additional resources
 
+* link:https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests[Flesch–Kincaid readability tests]
 * link:https://vale.sh/docs/topics/styles#metric[Vale documentation - `metric` extension point]
 * link:{repository-url}blob/main/.vale/styles/RedHat/ReadabilityGrade.yml[`ReadabilityGrade.yml` source code]


### PR DESCRIPTION
The RedHat/ReadabilityGrade.yml rule is confusing. It's not clear how the grade level is calculated. This PR adds the rule with a suggested Flesch-Kincaid Grade Level value of < 9.