### PR TITLE
vale-issue-867-expand: Bumped two OCP AsciiDoc rules to error status

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/ModuleContainsContentType/.vale.ini
+++ b/.vale/fixtures/OpenShiftAsciiDoc/ModuleContainsContentType/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ModuleContainsContentType` rule
 StylesPath = ../../../styles
-MinAlertLevel = suggestion
+MinAlertLevel = error
 [*.adoc]
 OpenShiftAsciiDoc.ModuleContainsContentType = YES

--- a/.vale/fixtures/OpenShiftAsciiDoc/XrefMustNotHaveNakedLabel/.vale.ini
+++ b/.vale/fixtures/OpenShiftAsciiDoc/XrefMustNotHaveNakedLabel/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `XrefMustNotHaveNakedLabel` rule
 StylesPath = ../../../styles
-MinAlertLevel = suggestion
+MinAlertLevel = error
 [*.adoc]
 OpenShiftAsciiDoc.XrefMustNotHaveNakedLabel = YES

--- a/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
@@ -1,7 +1,7 @@
 ---
 extends: occurrence
 scope: raw
-level: warning
+level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#module-file-metadata
 message: "Module is missing the '_mod-docs-content-type' variable."
 min: 1

--- a/.vale/styles/OpenShiftAsciiDoc/XrefMustNotHaveNakedLabel.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/XrefMustNotHaveNakedLabel.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 scope: raw
-level: suggestion
+level: error
 link: https://redhat-documentation.github.io/supplementary-style-guide/#link-text
 message: "The xref is missing link text."
 raw:


### PR DESCRIPTION
Expands on issue https://github.com/redhat-documentation/vale-at-red-hat/issues/867

**Analysis of remaining rules that are not at "error" status:**

* _AdditionalResourcesHeadingHasRoleID.yml:_ This doesn't break anything and is not actually used for anything in the build.

* _CheckDollarSymbolInTerminalBlock.yml:_ Too many false positives, suggest leaving it as is. Do not change.

* _HardWrappedLines.yml:_ Too many false positives. Do not change.

* _ModuleContainsContentType.yml:_ OK

* _ModuleContainsParentAssemblyComment.yml:_ this doesn't break anything and is not actually used for anything in the build. 

* _XrefMustNotHaveNakedLabel.yml:_ OK