### PR TITLE
Add IBM Secure Execution exception

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testvalid.adoc
@@ -95,3 +95,4 @@
 {capx-short}
 {capz-first}
 {capz-short}
+IBM Secure Execution

--- a/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
@@ -46,7 +46,7 @@ swap:
   factory-precaching-cli tool: "{factory-prestaging-tool}"
   GitOps ZTP: "{ztp}"
   Hybrid Cloud Console: "{hybrid-console-second}"
-  IBM(?! Cloud| Power| Power Virtual Server| LinuxONE| Z): "{ibm-title}"
+  IBM(?! Cloud| Power| Power Virtual Server| LinuxONE| Z| Secure Execution): "{ibm-title}"
   IBM Cloud(?! Bare Metal): "{ibm-cloud-title}"
   IBM Cloud Bare Metal Classic: "{ibm-cloud-bm-title}"
   IBM Power(?! Virtual Server): "{ibm-power-title}"


### PR DESCRIPTION
Add "IBM Secure Execution" as an exception to the OpenShift attributes rule.