### PR TITLE
Removing IBM suggested attribute rule

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testvalid.adoc
@@ -95,6 +95,3 @@
 {capx-short}
 {capz-first}
 {capz-short}
-IBM documentation
-IBM Secure Execution
-IBM Style

--- a/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
@@ -46,7 +46,6 @@ swap:
   factory-precaching-cli tool: "{factory-prestaging-tool}"
   GitOps ZTP: "{ztp}"
   Hybrid Cloud Console: "{hybrid-console-second}"
-  IBM(?! Cloud| Power| Power Virtual Server| LinuxONE| Z| Secure Execution| documentation| Style): "{ibm-title}"
   IBM Cloud(?! Bare Metal): "{ibm-cloud-title}"
   IBM Cloud Bare Metal Classic: "{ibm-cloud-bm-title}"
   IBM Power(?! Virtual Server): "{ibm-power-title}"


### PR DESCRIPTION
The rule that flags "IBM" is too simple and prone to false positives. In general, if a Vale rule is producing false positives, it's not fit for purpose and just adds noise and friction.

"When in doubt, leave it out" :smiley_cat: 