### PR TITLE
Adding numbered sequential callout rule fix

### DIFF
--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
@@ -3,6 +3,27 @@
 ----
 require 'sinatra' <1>
 
+get '/hi' do <1>
+  "Goodbye cruel world!"
+end
+key: value <2>
+key: another value <3>
+----
+<1> Library import
+<2> URL mapping
+// Rule skips any block containing ifdefs
+ifndef::test1[]
+<3> Some text
+endif::[]
+ifdef::test2[]
+<3> Some other text
+endif::[]
+
+//vale-fixture
+[source,ruby]
+----
+require 'sinatra' <1>
+
 get '/hi' do <2> <3>
   "Hello World!"
 end
@@ -16,10 +37,10 @@ end
 ----
 require 'sinatra' <1>
 
-get '/hi' do <1>
-  "Hello World!"
+get '/hi' do <2> <3>
+  "Hello World again!"
 end
-key: value <2> 
 ----
 <1> Library import
 <2> URL mapping
+<3> Response block

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -16,30 +16,44 @@ script: |
   prev_num := 0
   callout_regex := "^<(\\d+)>"
   listingblock_delim_regex := "^-{4,}$"
+  if_regex := "^ifdef::|ifndef::"
+  endif_regex := "^endif::\\[\\]"
+  inside_if := false
 
   for line in text.split(scope, "\n") {
     // trim trailing whitespace
     line = text.trim_space(line)
+
+    // check if we're entering a conditional block
+    if text.re_match(if_regex, line) {
+        inside_if = true
+    } else if text.re_match(endif_regex, line) {
+        inside_if = false
+    }
+
     //reset count if we hit a listing block delimiter
     if text.re_match(listingblock_delim_regex, line) {
       prev_num = 0
     }
 
-    if text.re_match(callout_regex, line) {
-      callout := text.re_find("<(\\d+)>", line)
-      for key, value in callout {
-        //trim angle brackets from string
-        trimmed := callout[key][0]["text"]
-        trimmed = text.trim_prefix(trimmed, "<")
-        trimmed = text.trim_suffix(trimmed, ">")
-        //cast string > int
-        num := text.atoi(trimmed)
-        //start counting
-        if num != prev_num+1 {
-          start := text.index(scope, line)
-          matches = append(matches, {begin: start, end: start + len(line)})
+    //only count callouts where there are no ifdefs
+    if !inside_if {
+      if text.re_match(callout_regex, line) {
+        callout := text.re_find("<(\\d+)>", line)
+        for key, value in callout {
+          //trim angle brackets from string
+          trimmed := callout[key][0]["text"]
+          trimmed = text.trim_prefix(trimmed, "<")
+          trimmed = text.trim_suffix(trimmed, ">")
+          //cast string > int
+          num := text.atoi(trimmed)
+          //start counting
+          if num != prev_num+1 {
+            start := text.index(scope, line)
+            matches = append(matches, {begin: start, end: start + len(line)})
+          }
+          prev_num = num
         }
-        prev_num = num
       }
     }
   }

--- a/tengo-rule-scripts/SequentialNumberedCallouts.tengo
+++ b/tengo-rule-scripts/SequentialNumberedCallouts.tengo
@@ -1,6 +1,6 @@
 /*
     Tengo Language
-    Checks that callouts outside the listing block are sequential 
+    Checks that callouts outside the listing block are sequential
     $ tengo SequentialNumberedCallouts.tengo <asciidoc_file_to_validate>
 */
 
@@ -20,30 +20,44 @@ scope += "\n"
 prev_num := 0
 callout_regex := "^<(\\d+)>"
 listingblock_delim_regex := "^-{4,}$"
+if_regex := "^ifdef::|ifndef::"
+endif_regex := "^endif::\\[\\]"
+inside_if := false
 
 for line in text.split(scope, "\n") {
   // trim trailing whitespace
   line = text.trim_space(line)
+
+  // check if we're entering a conditional block
+  if text.re_match(if_regex, line) {
+      inside_if = true
+  } else if text.re_match(endif_regex, line) {
+      inside_if = false
+  }
+
   //reset count if we hit a listing block delimiter
   if text.re_match(listingblock_delim_regex, line) {
     prev_num = 0
   }
 
-  if text.re_match(callout_regex, line) {
-    callout := text.re_find("<(\\d+)>", line)
-    for key, value in callout {
-      //trim angle brackets from string
-      trimmed := callout[key][0]["text"]
-      trimmed = text.trim_prefix(trimmed, "<")
-      trimmed = text.trim_suffix(trimmed, ">")
-      //cast string > int
-      num := text.atoi(trimmed)
-      //start counting
-      if num != prev_num+1 {
-        start := text.index(scope, line)
-        matches = append(matches, {begin: start, end: start + len(line)})
+  //only count callouts where there are no ifdefs
+  if !inside_if {
+    if text.re_match(callout_regex, line) {
+      callout := text.re_find("<(\\d+)>", line)
+      for key, value in callout {
+        //trim angle brackets from string
+        trimmed := callout[key][0]["text"]
+        trimmed = text.trim_prefix(trimmed, "<")
+        trimmed = text.trim_suffix(trimmed, ">")
+        //cast string > int
+        num := text.atoi(trimmed)
+        //start counting
+        if num != prev_num+1 {
+          start := text.index(scope, line)
+          matches = append(matches, {begin: start, end: start + len(line)})
+        }
+        prev_num = num
       }
-      prev_num = num
     }
   }
 }
@@ -51,5 +65,5 @@ for line in text.split(scope, "\n") {
 if len(matches) == 0 {
   fmt.println("Callouts are sequential")
 } else {
-  fmt.println(matches) 
+  fmt.println(matches)
 }


### PR DESCRIPTION
Based on the excellent work started in https://github.com/redhat-documentation/vale-at-red-hat/pull/827 (thanks @gaurav-nelson)

Updates the SequentialNumberedCallouts.yml rule to skip any callout blocks that include ifdefs.

![image](https://github.com/user-attachments/assets/2a52ad98-2045-4c0c-8032-794ff09f7d28)
