### PR TITLE
Add OpenShift "No 'Optional:' titles" rule

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/NoOptionalTitles/.vale.ini
+++ b/.vale/fixtures/OpenShiftAsciiDoc/NoOptionalTitles/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `NoOptionalTitles` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+OpenShiftAsciiDoc.NoOptionalTitles = YES

--- a/.vale/fixtures/OpenShiftAsciiDoc/NoOptionalTitles/testinvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/NoOptionalTitles/testinvalid.adoc
@@ -1,0 +1,9 @@
+//vale-fixture
+:_mod-docs-content-type: REFERENCE
+[id="optional-postinstall-configurations_{context}"]
+= Optional: Postinstall configurations
+
+== Optional: More postinstall configurations
+
+\\ == Optional: more options
+

--- a/.vale/fixtures/OpenShiftAsciiDoc/NoOptionalTitles/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/NoOptionalTitles/testvalid.adoc
@@ -1,0 +1,4 @@
+//vale-fixture
+:_mod-docs-content-type: REFERENCE
+[id="cli-basic-commands_{context}"]
+= No optional CLI commands

--- a/.vale/styles/OpenShiftAsciiDoc/NoOptionalTitles.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/NoOptionalTitles.yml
@@ -1,0 +1,8 @@
+---
+extends: existence
+scope: raw
+level: error
+link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#assembly-file-metadata
+message: "Do not begin a module or assembly title with 'Optional:'."
+raw:
+  - '(?<!\/\/)={1,5} Optional:'


### PR DESCRIPTION
Add an OpenShiftAsciiDoc rule that flags "Optional:" in titles as an error.