### PR TITLE
Add "vertical ellipsis" to TermsWarnings

### DIFF
--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -60,6 +60,7 @@ tarball
 terminate
 tooling
 transition
+vertical ellipsis
 vs
 Hybrid Cloud Console
 Cloud Console

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -41,7 +41,7 @@ swap:
   entitlement: repository|subscription
   execute: run|issue|start|enter
   find out: discover
-  hamburger|kebab menu|kebab: more options icon|options icon
+  hamburger|kebab menu|kebab|vertical ellipsis: more options icon|options icon
   he|she: you
   host name: hostname
   illegal: invalid|not allowed|incorrect


### PR DESCRIPTION
[ISG](https://www.ibm.com/docs/en/ibm-style?topic=elements-ui#menu) says not to use "vertical ellipsis" for the stacked dots menu (aka kebab menu).