### PR TITLE
Syntax correction to avoid 'Invalid Value' error message

### DIFF
--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -20,7 +20,7 @@ swap:
   "(?<!pseudo-)ops": operations
   "(?<!self-)hosted engine|hosted-engine": self-hosted engine
   "bare metal( clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?)": bare-metal$1
-  "bare-metal(?! clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal
+  "bare-metal(?: clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal
   "[bB]asic [aA]uth": Basic HTTP authentication|Basic authentication
   "a lot(?: of)?": many|much
   "best of breed|best-of-breed": best in class


### PR DESCRIPTION
modified:   .vale/styles/RedHat/TermsErrors.yml

When running Vale with RedHat style, I was getting this message: 

```
E201 Invalid value [styles/RedHat/TermsErrors.yml:24:4]:

  24*   "bare-metal( clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal
  25    "[bB]asic [aA]uth": Basic HTTP authentication|Basic authentication
  26    "a lot(?: of)?": many|much

capture group not supported; use '(?:' instead of '('
```

It seems there was a syntax error in the YAML. I believe I've fixed it in this commit.