### PR TITLE
Adding trailing backslash rule

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/TrailingBackslash/.vale.ini
+++ b/.vale/fixtures/OpenShiftAsciiDoc/TrailingBackslash/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `TrailingBackslash` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+OpenShiftAsciiDoc.TrailingBackslash = YES

--- a/.vale/fixtures/OpenShiftAsciiDoc/TrailingBackslash/testinvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/TrailingBackslash/testinvalid.adoc
@@ -1,0 +1,11 @@
+//vale-fixture
+[source,terminal]
+----
+oc get my lunch\
+----
+
+//vale-fixture
+[source,terminal]
+----
+C:\Program Files\
+----

--- a/.vale/fixtures/OpenShiftAsciiDoc/TrailingBackslash/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/TrailingBackslash/testvalid.adoc
@@ -1,0 +1,46 @@
+[source,terminal]
+----
+$ oc get my lunch
+----
+
+[source,terminal]
+----
+# oc get my lunch
+----
+
+.Example
+[source,terminal]
+----
+$ az role assignment create --role "<privileged_role>" \// <1>
+----
+
+[source,terminal]
+----
+sh-4.2# chroot /host
+----
+
+[source,terminal]
+----
+.
+├── CODEOWNERS
+├── README.md
+└── scripts
+    └── validate-vale-rules.sh
+----
+
+[source,terminal]
+----
+(undercloud)$ cd go/to/path
+----
+
+[source,yaml]
+----
+include::yaml/boundary-clock-ptp-config.yaml[]
+----
+
+.Example
+[source,terminal]
+----
+$ az role assignment \
+  create --role "<privileged_role>"
+----

--- a/.vale/styles/OpenShiftAsciiDoc/TrailingBackslash.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/TrailingBackslash.yml
@@ -1,0 +1,9 @@
+---
+extends: existence
+scope: raw
+level: error
+message: "Code example ends with an unescaped trailing backslash."
+action:
+  name: remove
+raw:
+ - '\\(?=\n----)'


### PR DESCRIPTION
Trailing backslashes in codeblocks break the openshift-docs Asciibinder build. Backslashes are only a problem in asciibinder when they come just before the end of a codeblock.