### PR TITLE
improve Spelling rule by using word boundaries

### DIFF
--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -22,15 +22,14 @@ filters:
   - "[bB]indable"
   - "[bB]oolean"
   - "[bB]ootable"
-  - "[bB]reakpoint"
-  - "[bB]reakpoints"
-  - "[cC]he"
+  - "[bB]reakpoint(s)?"
+  - '\b[cC]he\b'
   - "[cC]hrony"
   - "[cC]lassloading"
   - "[cC]lasspath"
   - "[cC]olocate"
   - "[cC]olocation"
-  - "[cC]onfig"
+  - '\b[cC]onfig\b'
   - "[cC]ontainerd"
   - "[cC]orequisite"
   - "[cC]ustomizer"
@@ -42,11 +41,9 @@ filters:
   - "[dD]ecompiler"
   - "[dD]efragmentation"
   - "[dD]eserialization"
-  - "[dD]eserialize"
-  - "[dD]eserialized"
-  - "[dD]esynchronize"
-  - "[dD]esynchronized"
-  - "[dD]ev"
+  - "[dD]eserialize(d)?"
+  - "[dD]esynchronize(d)?"
+  - '\b[dD]ev\b'
   - "[dD]ev[wW]orkspace"
   - "[dD]evfile"
   - "[dD]istro"
@@ -61,7 +58,7 @@ filters:
   - "[fF]indability"
   - "[gG]bps"
   - "[gG]ibibyte"
-  - "[gG]it"
+  - '\b[gG]it\b'
   - "[gG]lock"
   - "[gG]radle"
   - "[gG]rafana"
@@ -75,7 +72,7 @@ filters:
   - "[iI]ntrarecord"
   - "[iI]ntrasystem"
   - "[iI]nvocable"
-  - "[iI]tem"
+  - '\b[iI]tem\b'
   - "[jJ]et[bB]rains"
   - "[jJ]ournald"
   - "[jJ]ournaling"
@@ -143,7 +140,7 @@ filters:
   - "[pP]ostoperation"
   - "[pP]ostrequisite"
   - "[pP]recompile"
-  - "[pP]reconfigured"
+  - "[pP]reconfigure(d)?"
   - "[pP]reenrollment"
   - "[pP]reformatted"
   - "[pP]regenerated"
@@ -197,25 +194,17 @@ filters:
   - "[sS]ervlet"
   - "[sS]etter"
   - "[sS]harding"
-  - "[Ss]u"
-  - "[sS]ubcommand"
-  - "[sS]ubcommands"
-  - "[sS]ubmenu"
-  - "[sS]ubmenus"
-  - "[sS]ubnetwork"
-  - "[sS]ubnetworks"
-  - "[sS]ubpackage"
-  - "[sS]ubpackages"
-  - "[sS]ubpath"
-  - "[sS]ubpaths"
-  - "[sS]ubstep"
-  - "[sS]ubsteps"
-  - "[sS]ubtest"
-  - "[sS]ubtests"
-  - "[sS]ubuser"
-  - "[sS]ubusers"
-  - "[sS]ubvolume"
-  - "[sS]ubvolumes"
+  - '\b[Ss]u\b'
+  - "[sS]ubcommand(s)?"
+  - "[sS]ubmenu(s)?"
+  - "[sS]ubnet(s)?"
+  - "[sS]ubnetwork(s)?"
+  - "[sS]ubpackage(s)?"
+  - "[sS]ubpath(s)?"
+  - "[sS]ubstep(s)?"
+  - "[sS]ubtest(s)?"
+  - "[sS]ubuser(s)?"
+  - "[sS]ubvolume(s)?"
   - "[sS]ysctl"
   - "[sS]yslog"
   - "[sS]ystemd"
@@ -254,6 +243,7 @@ filters:
   - Applixware
   - Asciidoctor
   - AssertJ
+  - autoconfigure
   - autolink
   - aws
   - AWS
@@ -406,6 +396,7 @@ filters:
   - Mirantis
   - Mockito
   - MongoDB
+  - multischema
   - MySQL
   - Nagios
   - Narayana
@@ -443,6 +434,7 @@ filters:
   - Podman
   - PostgreSQL
   - PowerShell
+  - precache
   - Prometheus
   - proxied
   - Pytorch
@@ -479,6 +471,10 @@ filters:
   - startx
   - STMicroelectronics
   - Stratis
+  - subaddress
+  - subcapacity
+  - subtab
+  - superobject
   - Suchow
   - SVG
   - Symfony

--- a/tools/validate-vale-rules.sh
+++ b/tools/validate-vale-rules.sh
@@ -15,7 +15,7 @@ Rule() {
     VALIDALERTSCOUNT="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testvalid.adoc" | wc -l)"
     INVALIDALERTS="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testinvalid.adoc" | wc -l)"
     INVALIDLINES="$(grep -cve '.+' "$DIR/testinvalid.adoc" || true)"
-    echo "$INVALIDLINES in .vale/fixtures/RedHat/$RULE/" 
+    echo "$INVALIDLINES in .vale/fixtures/RedHat/$RULE/"
     INVALIDGAP=$((INVALIDLINES - INVALIDALERTS))
     if [ "$VALIDALERTSCOUNT" -gt 0 ]
     then
@@ -72,7 +72,7 @@ done
 # This scripts runs the  suite for each rule in the `RedHat` style.
 TOTAL=0
 for RULE in $(find .vale/styles/RedHat/ -name '*.yml' | cut -d/ -f 4 | cut -d. -f1 | sort)
-do  
+do
     Rule
 done
 


### PR DESCRIPTION
By using regex word boundary (\b) delimiters, the spelling rule applies to individual words rather than a word that might contain the regex filter. For example, "\b[cC]he\b" will match only "che" and "Che" rather than a regex filter without word boundary delimiters, for example, "[cC]he" that would match misspelled words that contain the regex, such as "aache" or "chemitsry".

Closes #894 