### PR TITLE
Warn when 'police' is used in place of 'policy'

### DIFF
--- a/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testinvalid.adoc
@@ -43,6 +43,8 @@ on-prem
 on-premises
 opt into
 opting into
+police
+polices
 preload
 preloaded
 print out

--- a/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsWarnings/testvalid.adoc
@@ -63,6 +63,8 @@ operates like
 perform like
 performs like
 plugin
+policy
+policies
 preinstall
 preinstalled
 print

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -56,6 +56,8 @@ swap:
   may: might|can
   on-premises|on-prem|on premise: on-premise|on-site|in-house
   opt into|opting into: opt in
+  police: policy
+  polices: policies
   preload: preinstall
   preloaded: preinstalled
   print out: print


### PR DESCRIPTION
Because of the similarity of the two words, it is [not uncommon](https://docs.redhat.com/search/?p=1&rows=10&documentKind=Documentation&q=polices) to find the word 'police' or 'polices' used in place of 'policy' or 'policies'. As the former is highly unlikely to appear in software documentation, I propose to issue a warning when this word is found.