### PR TITLE
Revert "Add "login to" error"

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -259,7 +259,6 @@ log into
 log off of
 log onto
 logfile
-login to
 lots of
 main directory
 make file

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -260,7 +260,6 @@ swap:
   log off of: log off from
   log onto: log on to
   logfile: log file
-  login to: log in to
   lots of|bunches of: many
   main directory: root directory
   make file: makefile


### PR DESCRIPTION
Reverts redhat-documentation/vale-at-red-hat#903

Reverting because this rule is case insensitive. I want to prevent "Login to", not "login to". Personally, I think "login to" sounds awful but someone wrote "having a login to the cluster can help you ..."
