### PR TITLE
Add 'k8s' to TermsErrors

### DIFF
--- a/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/CaseSensitiveTerms/testinvalid.adoc
@@ -240,7 +240,6 @@ Junit
 junit
 jvm
 Jvm
-k8s
 kbase
 Kernel
 kernel-based virtual machine

--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -231,6 +231,7 @@ JavaBean
 joblog
 jobstream
 judgement
+k8s
 keep in mind
 kernelspace
 kick off

--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -177,7 +177,7 @@ swap:
   knowledgebase: Knowledgebase
   ksession|knowledge session: KIE session
   Kubelet(?! Stats Receiver): kubelet
-  kubernetes|k8s: Kubernetes
+  kubernetes: Kubernetes
   kvm: KVM
   Lan|lan: LAN
   Librados|LIBRADOS: librados

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -233,6 +233,7 @@ swap:
   joblog: job log
   jobstream: job stream
   judgement: judgment
+  k8s: Kubernetes
   keep in mind: remember
   kernelspace: kernel-space
   kick off: start


### PR DESCRIPTION
Add 'k8s' to TermsErrors.
Removed 'k8s' from CaseSensitiveTerms because the rule does not find 'K8s'.