### PR TITLE
Lowering error level for UnsetAttributes.yml

### DIFF
--- a/.vale/styles/AsciiDoc/UnsetAttributes.yml
+++ b/.vale/styles/AsciiDoc/UnsetAttributes.yml
@@ -1,6 +1,6 @@
 ---
 extends: script
-level: warning
+level: suggestion
 message: "Set attribute directive does not have a corresponding unset attribute directive."
 link: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/#unset-a-document-attribute-in-the-body
 scope: raw


### PR DESCRIPTION
Since this is not technically an error at all for AsciiDoctor, and we allow our attributes to go unset generally, this rule does not need to be set to Warning. 