### PR TITLE
Drop error level of CaseSensitiveTerms.yml

### DIFF
--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -1,7 +1,7 @@
 ---
 extends: substitution
 ignorecase: false
-level: error
+level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/casesensitiveterms/
 message: "Use '%s' rather than '%s'."
 action:


### PR DESCRIPTION
AsciiDoc edge cases with setting attributes can cause Vale linting runs to fail on false positives. Dropping this error level to warning to ensure CIs pass the build.