### PR TITLE
Add word boundary to "as per" rule to increase accuracy

### DIFF
--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -12,7 +12,7 @@ swap:
   "(?<!-)pm": PM
   "(?<!-|I )am": AM
   "(?<!.)io": I/O
-  "(?<!as well )as per": according to|as|as in
+  '(?<!as well )\bas per\b': according to|as|as in
   "(?<!kernel )oops": kernel oops
   "(?<!mobile |cell )phone": "telephone|cell phone|mobile phone"
   "(?<!Mozilla )Firefox": Mozilla Firefox


### PR DESCRIPTION
Add word boundary to "as per" rule to increase accuracy