### PR TITLE
improve Using style rule by using word boundaries

### DIFF
--- a/.vale/fixtures/RedHat/Using/testvalid.adoc
+++ b/.vale/fixtures/RedHat/Using/testvalid.adoc
@@ -4,3 +4,4 @@ Developers are using the latest version of the framework.
 Switching to using cloud storage improved our backup efficiency.
 The documentation provides guidelines about using third-party libraries.
 Users experience faster load times when using the optimized query.
+Strategies focusing on data transfer speeds are improving.

--- a/.vale/styles/RedHat/Using.yml
+++ b/.vale/styles/RedHat/Using.yml
@@ -11,4 +11,4 @@ action:
     - "$1 by using" # replace
 tokens:
   - tag: NN|NNP|NNPS|NNS
-  - pattern: using
+  - pattern: \busing\b


### PR DESCRIPTION
Nitpick improvement to the `Using.yml` style rule.

Fixes incorrect flagging of a word such as "focusing":

```
/vale_app/styles/RedHat # vale "Here is a rule focusing on clarity."

 stdin.txt
 1:11  warning  Use 'by using' instead of       RedHat.Using
                'using' when it follows a noun
                for clarity and grammatical
                correctness.

✖ 0 errors, 1 warning and 0 suggestions in stdin.
```