### PR TITLE
Add CI/CD exception to the Slash rule

### DIFF
--- a/.vale/styles/RedHat/Slash.yml
+++ b/.vale/styles/RedHat/Slash.yml
@@ -15,6 +15,7 @@ exceptions:
   - "0/"
   - "[Ii]nput/[Oo]utput"
   - "C/C"
+  - "CI/CD"
   - "client/server"
   - "I/O"
   - "N/A"


### PR DESCRIPTION
"CI/CD" is a common concept promoted by Red Hat. See: https://www.redhat.com/en/topics/devops/what-is-ci-cd.