### PR TITLE
Update regex to match ifeval only at the beginning of a line

### DIFF
--- a/.vale/styles/AsciiDoc/ValidConditions.yml
+++ b/.vale/styles/AsciiDoc/ValidConditions.yml
@@ -15,7 +15,7 @@ script: |
 
   if_regex := "^ifdef::.+\\[\\]"
   ifn_regex := "^ifndef::.+\\[\\]"
-  ifeval_regex := "ifeval::\\[.+\\]"
+  ifeval_regex := "^ifeval::\\[.+\\]"
   endif_regex := "^endif::.*\\[\\]"
 
   for line in text.split(scope, "\n") {


### PR DESCRIPTION
Fix #953. 