### PR TITLE
fix: allow the transitive phrasal verb "built in"

### DIFF
--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -88,7 +88,7 @@ swap:
   break point: breakpoint
   bring up: start|power on|open|turn on
   bufferpool: buffer pool
-  builtin|built in: built-in
+  builtin: built-in
   busmaster: bus master
   busses: buses
   byte code: bytecode


### PR DESCRIPTION
"built in" should not be unconditionally substituted by "built-in". "Built in" is the valid past principle form of the transitive phrasal verb "to build in", as [seen](https://www.oed.com/dictionary/build_v?tab=phrasal_verbs#1351285480) in the Oxford English Dictionary.