### PR TITLE
fix: allow the .env (dotenv) dotfile

### DIFF
--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -10,6 +10,7 @@ action:
 swap:
   "(?<!-)healthcheck|health-check": health check
   "(?<!-)pm": PM
+  "(?<!-|.)env": environment
   "(?<!-|I )am": AM
   "(?<!.)io": I/O
   '(?<!as well )\bas per\b': according to|as|as in
@@ -186,7 +187,6 @@ swap:
   end user: user
   end-user interface: graphical interface|interface
   enum: data enumeration
-  env: environment
   EUI: graphical user interface|interface
   evangelist: influencer|advocate|ambassador
   fatal: unrecoverable


### PR DESCRIPTION
`.env` is a popular dotfile used by, e.g., <https://www.npmjs.com/package/dotenv>.

Additionally, allow the GNU-style and POSIX-style long option names `-env` and `--env`, respectively; a script or utility somewhere may elect "env" as an option name.

All other uses remain prohibited.