### PR TITLE
fix: add bootc to RedHat.Spelling

### DIFF
--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -472,7 +472,6 @@ filters:
   - SELinux
   - Semeru
   - Shadowman
-  - ShellCheck
   - Skopeo
   - SLAs
   - SmallRye
@@ -521,7 +520,6 @@ filters:
   - Wordpress
   - XString
   - XWayland
-  - yamllint
   - Yana
   - Yeoman
   - ZCentral

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -255,6 +255,7 @@ filters:
   - Bitbucket
   - BOM
   - Bonjour
+  - bootc
   - Bouncy Castle
   - btn
   - Btrfs
@@ -471,6 +472,7 @@ filters:
   - SELinux
   - Semeru
   - Shadowman
+  - ShellCheck
   - Skopeo
   - SLAs
   - SmallRye
@@ -519,6 +521,7 @@ filters:
   - Wordpress
   - XString
   - XWayland
+  - yamllint
   - Yana
   - Yeoman
   - ZCentral


### PR DESCRIPTION
Red Hat has a strong presence in bootc:
<https://github.com/bootc-dev/bootc/blob/main/MAINTAINERS.md#maintainers>.