### PR TITLE
chore: add file-based catalogs (FBC)

### DIFF
--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -117,7 +117,7 @@ swap:
   Faq|faq|F.A.Q: FAQ
   fault tolerant: fault-tolerant
   fault-tolerance: fault tolerance
-  fbc|Fbc|FBC: [fF]ile-based catalogs?
+  fbc|Fbc|FBC: file-based catalog
   fedora project: Fedora™ Project
   filestore|File Store: FileStore
   Firewalld|firewallD|FirewallD: firewalld


### PR DESCRIPTION
From the [Operator Lifecycle Manager](https://olm.operatorframework.io/docs/reference/file-based-catalogs/).