### PR TITLE
OpenShiftAsciiDoc - no alphanumeric charaters in headings

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/HeadingsAlphanumeric/.vale.ini
+++ b/.vale/fixtures/OpenShiftAsciiDoc/HeadingsAlphanumeric/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `HardWrappedLines` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+OpenShiftAsciiDoc.HeadingsAlphanumeric = YES

--- a/.vale/fixtures/OpenShiftAsciiDoc/HeadingsAlphanumeric/testinvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/HeadingsAlphanumeric/testinvalid.adoc
@@ -1,0 +1,8 @@
+//vale-fixture
+= Don't Use: Special Characters in Headings
+
+//vale-fixture
+== No @Symbols! Here
+
+//vale-fixture
+== No periods.

--- a/.vale/fixtures/OpenShiftAsciiDoc/HeadingsAlphanumeric/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/HeadingsAlphanumeric/testvalid.adoc
@@ -1,0 +1,9 @@
+//vale-fixture
+= Valid Headings with Alphanumeric Characters Only
+
+//vale-fixture
+== Exceptions include attribute references like {product-name}
+
+== Also allow single quotes even though we don't like them
+
+== And `backticks` are allowed too even though I cannot remember if we allow them in the style guide

--- a/.vale/styles/OpenShiftAsciiDoc/HeadingsAlphanumeric.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/HeadingsAlphanumeric.yml
@@ -1,0 +1,9 @@
+---
+extends: existence
+scope: raw
+level: error
+link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#anchoring-in-module-files
+message: "Headings should only contain alphanumeric characters."
+nonword: true
+tokens:
+  - "^=+\\s+.*[^a-zA-Z0-9\\s\\{\\}'`-].*$"


### PR DESCRIPTION
PV1 fails late in the build process if the headings aren't alphanumeric. It balks at even having periods in them.