### PR TITLE
Adding CodeBlockSubsVerbatim rule

### DIFF
--- a/.vale/fixtures/AsciiDoc/CodeBlockSubsVerbatim/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/CodeBlockSubsVerbatim/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `CodeBlockSubsVerbatim` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+AsciiDoc.CodeBlockSubsVerbatim = YES

--- a/.vale/fixtures/AsciiDoc/CodeBlockSubsVerbatim/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/CodeBlockSubsVerbatim/testinvalid.adoc
@@ -1,0 +1,109 @@
+//vale-fixture
+[source,terminal]
+----
+until PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1" >/dev/null 2>&1; do
+----
+
+//vale-fixture
+[source,bash]
+----
+command &> /dev/null
+----
+
+//vale-fixture
+[source,shell]
+----
+echo "error" >&2
+----
+
+//vale-fixture
+[source,terminal]
+----
+./script.sh 2>&1 | tee output.log
+----
+
+//vale-fixture
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <pgvector-postgresql-deployment>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: <pgvector-postgresql-app-label>
+  template:
+    metadata:
+      labels:
+        app: <pgvector-postgresql-app-label>
+    spec:
+      containers:
+      - name: postgres
+        image: pgvector/pgvector:pg16
+        ports:
+        - name: postgres
+          containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: <pgvector-postgresql-credentials-secret>
+              key: POSTGRES_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: <pgvector-postgresql-credentials-secret>
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: <pgvector-postgresql-credentials-secret>
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+
+        # Replace TCP socket probes with exec probes that validate SQL readiness.
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 6
+
+        # Create the pgvector extension after PostgreSQL is actually accepting SQL.
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Waiting for PostgreSQL to be ready before enabling pgvector..."
+                until PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1" >/dev/null 2>&1; do
+                  sleep 2
+                done
+                PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+      volumes:
+      - name: pgdata
+        persistentVolumeClaim:
+          claimName: <pgvector-postgresql-pvc>
+----

--- a/.vale/fixtures/AsciiDoc/CodeBlockSubsVerbatim/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/CodeBlockSubsVerbatim/testvalid.adoc
@@ -1,0 +1,117 @@
+[source,terminal,subs=verbatim]
+----
+until PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1" >/dev/null 2>&1; do
+----
+
+[source,bash,subs="verbatim"]
+----
+command &> /dev/null
+----
+
+[source,shell,subs="+quotes,verbatim"]
+----
+echo "error" >&2
+----
+
+[source,terminal,subs="verbatim,+quotes"]
+----
+./script.sh 2>&1 | tee output.log
+----
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+----
+
+[source,go]
+----
+func main() {
+    fmt.Println("Hello")
+}
+----
+
+[source,yaml,subs="verbatim,attributes"]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <pgvector-postgresql-deployment>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: <pgvector-postgresql-app-label>
+  template:
+    metadata:
+      labels:
+        app: <pgvector-postgresql-app-label>
+    spec:
+      containers:
+      - name: postgres
+        image: pgvector/pgvector:pg16
+        ports:
+        - name: postgres
+          containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: <pgvector-postgresql-credentials-secret>
+              key: POSTGRES_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: <pgvector-postgresql-credentials-secret>
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: <pgvector-postgresql-credentials-secret>
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+
+        # Replace TCP socket probes with exec probes that validate SQL readiness.
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 6
+
+        # Create the pgvector extension after PostgreSQL is actually accepting SQL.
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Waiting for PostgreSQL to be ready before enabling pgvector..."
+                until PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1" >/dev/null 2>&1; do
+                  sleep 2
+                done
+                PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+      volumes:
+      - name: pgdata
+        persistentVolumeClaim:
+          claimName: <pgvector-postgresql-pvc>
+----

--- a/.vale/styles/AsciiDoc/CodeBlockSubsVerbatim.yml
+++ b/.vale/styles/AsciiDoc/CodeBlockSubsVerbatim.yml
@@ -1,0 +1,73 @@
+---
+extends: script
+level: error
+message: "Code block contains shell redirection '%s' but is missing 'subs=verbatim'. Add 'subs=verbatim' or 'subs=\"+quotes,verbatim\"' to prevent parsing issues."
+link: https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  // Regex patterns
+  multiline_comment_pattern := "(?s)\n////.*?////\n"
+  source_block_attr_pattern := `^\[source,`
+  subs_verbatim_pattern := `(?i)subs\s*=\s*["']?[^"'\]]*verbatim`
+  code_block_delimiter_pattern := `^----`
+  shell_redirection_pattern := `\d*>&\d+|&>>?`
+
+  // Clean out multi-line comments
+  scope = text.re_replace(multiline_comment_pattern, scope, "")
+  // Ensure trailing newline
+  scope += "\n"
+
+  lines := text.split(scope, "\n")
+  in_code_block := false
+  block_has_subs_verbatim := false
+  current_pos := 0
+
+  for line in lines {
+    line_start := current_pos
+    line_len := len(line)
+
+    // Check for code block attribute line with [source,...] pattern
+    if text.re_match(source_block_attr_pattern, line) {
+      // Check if subs=verbatim or subs="+quotes,verbatim" etc. is present
+      if text.re_match(subs_verbatim_pattern, line) {
+        block_has_subs_verbatim = true
+      } else {
+        block_has_subs_verbatim = false
+      }
+    }
+
+    // Check for code block delimiter
+    if text.re_match(code_block_delimiter_pattern, line) {
+      in_code_block = !in_code_block
+      if !in_code_block {
+        // Reset when exiting block
+        block_has_subs_verbatim = false
+      }
+    }
+
+    // If inside a code block without subs=verbatim, check for shell redirections
+    // Match patterns like 2>&1, >&2, 1>&2, &>, &>>
+    // These can cause AsciiDoc parsing issues
+    if in_code_block && !block_has_subs_verbatim {
+      if text.re_match(shell_redirection_pattern, line) {
+        // Find the actual match position within the line
+        match_result := text.re_find(shell_redirection_pattern, line)
+        if match_result != undefined && len(match_result) > 0 {
+          // re_find returns array of arrays: [[{begin: N, end: M, text: "..."}]]
+          match_info := match_result[0][0]
+          match_text := match_info["text"]
+          match_start := match_info["begin"]
+          matches = append(matches, {
+            begin: line_start + match_start,
+            end: line_start + match_start + len(match_text)
+          })
+        }
+      }
+    }
+
+    // Move position forward (add 1 for newline)
+    current_pos += line_len + 1
+  }

--- a/tengo-rule-scripts/CodeBlockSubsVerbatim.tengo
+++ b/tengo-rule-scripts/CodeBlockSubsVerbatim.tengo
@@ -1,0 +1,78 @@
+/*
+    Tengo Language
+    $ tengo CodeBlockSubsVerbatim.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+scope := os.read_file(input[2])
+matches := []
+
+// Regex patterns
+multiline_comment_pattern := "(?s)\n////.*?////\n"
+source_block_attr_pattern := `^\[source,`
+subs_verbatim_pattern := `(?i)subs\s*=\s*["']?[^"'\]]*verbatim`
+code_block_delimiter_pattern := `^----`
+shell_redirection_pattern := `\d*>&\d+|&>>?`
+
+// Clean out multi-line comments
+scope = text.re_replace(multiline_comment_pattern, scope, "")
+// Ensure trailing newline
+scope += "\n"
+
+lines := text.split(scope, "\n")
+in_code_block := false
+block_has_subs_verbatim := false
+current_pos := 0
+
+for line in lines {
+  line_start := current_pos
+  line_len := len(line)
+
+  // Check for code block attribute line with [source,...] pattern
+  if text.re_match(source_block_attr_pattern, line) {
+    // Check if subs=verbatim or subs="+quotes,verbatim" etc. is present
+    if text.re_match(subs_verbatim_pattern, line) {
+      block_has_subs_verbatim = true
+    } else {
+      block_has_subs_verbatim = false
+    }
+  }
+
+  // Check for code block delimiter
+  if text.re_match(code_block_delimiter_pattern, line) {
+    in_code_block = !in_code_block
+    if !in_code_block {
+      // Reset when exiting block
+      block_has_subs_verbatim = false
+    }
+  }
+
+  // If inside a code block without subs=verbatim, check for shell redirections
+  // Match patterns like 2>&1, >&2, 1>&2, &>, &>>
+  // These can cause AsciiDoc parsing issues
+  if in_code_block && !block_has_subs_verbatim {
+    if text.re_match(shell_redirection_pattern, line) {
+      // Find the actual match position within the line
+      match_result := text.re_find(shell_redirection_pattern, line)
+      if match_result != undefined && len(match_result) > 0 {
+        // re_find returns array of arrays: [[{begin: N, end: M, text: "..."}]]
+        match_info := match_result[0][0]
+        match_start := match_info["begin"]
+        match_text := match_info["text"]
+        matches = append(matches, {
+          begin: line_start + match_start,
+          end: line_start + match_start + len(match_text)
+        })
+      }
+    }
+  }
+
+  // Move position forward (add 1 for newline)
+  current_pos += line_len + 1
+}
+
+fmt.println(matches)


### PR DESCRIPTION
Created .vale/styles/AsciiDoc/CodeBlockSubsVerbatim.yml
  - Detects shell redirection patterns like 2>&1, >&2, &>, &>> in code blocks
  - Only flags when subs=verbatim is not present on the code block
```
Example output

4:120  error  Code block contains shell redirection '2>&1' 
       but is missing 'subs=verbatim'. Add 'subs=verbatim' or
       'subs="+quotes,verbatim"' to prevent parsing issues.
```

The rule properly handles:
  - `[source,terminal,subs=verbatim]` - no warning
  - `[source,bash,subs="verbatim"]` - no warning
  - `[source,shell,subs="+quotes,verbatim"]` - no warning
  - Code blocks without `subs=verbatim` containing `2>&1`, `>&2`, `&>` - error