### PR TITLE
Adding no gerunds in titles Suggestion rule

### DIFF
--- a/.vale/fixtures/RedHat/NoGerundsInTitles/.vale.ini
+++ b/.vale/fixtures/RedHat/NoGerundsInTitles/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `NoGerundsInTitles` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.NoGerundsInTitles = YES

--- a/.vale/fixtures/RedHat/NoGerundsInTitles/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/NoGerundsInTitles/testinvalid.adoc
@@ -1,0 +1,25 @@
+== Getting Started Guide
+
+=== Running Tests
+
+==== Testing Edge Cases
+
+===== Validating Input Data
+
+= Managing User Accounts
+
+== Creating New Projects
+
+== Understanding the Architecture
+
+=== Deploying to Production
+
+==== Monitoring System Performance
+
+===== Troubleshooting Common Issues
+
+=== Building the Dashboard
+
+==== Configuring Database Settings
+
+===== Installing Dependencies

--- a/.vale/fixtures/RedHat/NoGerundsInTitles/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/NoGerundsInTitles/testinvalid.adoc
@@ -1,25 +1,83 @@
-== Getting Started Guide
+== Getting started guide
 
-=== Running Tests
+=== Running tests
 
-==== Testing Edge Cases
+==== Testing edge cases
 
-===== Validating Input Data
+===== Validating input data
 
-= Managing User Accounts
+= Managing user accounts
 
-== Creating New Projects
+== Creating new projects
 
-== Understanding the Architecture
+== Understanding the architecture
 
-=== Deploying to Production
+=== Deploying to production
 
-==== Monitoring System Performance
+==== Monitoring system performance
 
-===== Troubleshooting Common Issues
+===== Troubleshooting common issues
 
-=== Building the Dashboard
+=== Building the dashboard
 
-==== Configuring Database Settings
+==== Configuring database settings
 
-===== Installing Dependencies
+===== Installing dependencies
+
+== Writing documentation
+
+=== Making API calls
+
+==== Using the CLI
+
+===== Moving resources
+
+= Saving configurations
+
+== Replacing components
+
+=== Enabling features
+
+==== Handling errors
+
+===== Scaling the application
+
+= Deleting records
+
+== Upgrading clusters
+
+=== Defining variables
+
+==== Changing permissions
+
+===== Closing connections
+
+= Describing resources
+
+== Providing feedback
+
+=== Reducing complexity
+
+==== Merging branches
+
+===== Resolving conflicts
+
+= Formatting output
+
+== Debugging applications
+
+=== Mapping network drives
+
+==== Submitting a request
+
+===== Planning the migration
+
+= Modeling data
+
+== Scheduling jobs
+
+=== Executing commands
+
+==== Composing messages
+
+===== Choosing options

--- a/.vale/fixtures/RedHat/NoGerundsInTitles/testvalid.adoc
+++ b/.vale/fixtures/RedHat/NoGerundsInTitles/testvalid.adoc
@@ -1,0 +1,23 @@
+== Configure the application
+
+=== Set up authentication
+
+==== Define user roles
+
+===== Specify access permissions
+
+== Review troubleshooting information
+
+=== Debug application errors
+
+==== Optimize query performance
+
+===== Decommission the CCMS
+
+== Validate API responses
+
+=== Process user requests
+
+==== Handle error conditions
+
+===== Return status codes

--- a/.vale/fixtures/RedHat/NoGerundsInTitles/testvalid.adoc
+++ b/.vale/fixtures/RedHat/NoGerundsInTitles/testvalid.adoc
@@ -21,3 +21,41 @@
 ==== Handle error conditions
 
 ===== Return status codes
+
+== String operations
+
+=== Spring Boot configuration
+
+==== Ring buffer implementation
+
+===== Bring up the system
+
+= Ping the server
+
+== Thing to consider
+
+=== Existing configurations
+
+==== Underlying architecture
+
+===== Following steps
+
+= Remaining tasks
+
+== Outstanding issues
+
+=== Preceding events
+
+==== Leading practices
+
+===== Pending changes
+
+= During the upgrade
+
+== Missing prerequisites
+
+=== Interesting patterns
+
+==== Everything you need to know
+
+===== Nothing to configure

--- a/.vale/styles/RedHat/NoGerundsInTitles.yml
+++ b/.vale/styles/RedHat/NoGerundsInTitles.yml
@@ -1,0 +1,11 @@
+---
+extends: existence
+message: "Avoid gerunds in topic titles. Use the imperative form instead."
+level: suggestion
+scope: heading
+tokens:
+  - '^\w+ing\b'
+action:
+  name: suggest
+  params:
+    - NoGerundsInTitles.tengo

--- a/.vale/styles/RedHat/NoGerundsInTitles.yml
+++ b/.vale/styles/RedHat/NoGerundsInTitles.yml
@@ -1,10 +1,52 @@
 ---
 extends: existence
-message: "Avoid gerunds in topic titles. Use the imperative form instead."
+message: "Where possible, avoid using gerunds in topic titles. Use the imperative form instead."
 level: suggestion
 scope: heading
 tokens:
   - '^\w+ing\b'
+exceptions:
+  # Root words ending in -ing (not gerunds)
+  - String
+  - Spring
+  - Ring
+  - Bring
+  - Thing
+  - Swing
+  - Ping
+  - Cling
+  - Fling
+  - Sling
+  - Sting
+  - Wing
+  - Wring
+  - King
+  # Compound -thing words
+  - Everything
+  - Something
+  - Nothing
+  - Anything
+  # Prepositions and conjunctions ending in -ing
+  - During
+  # Participial adjectives commonly used as modifiers in titles
+  - Existing
+  - Underlying
+  - Corresponding
+  - Remaining
+  - Outstanding
+  - Preceding
+  - Overarching
+  - Forthcoming
+  - Longstanding
+  - Following
+  - Interesting
+  - Competing
+  - Overwhelming
+  - Overlapping
+  - Lingering
+  - Missing
+  - Leading
+  - Pending
 action:
   name: suggest
   params:

--- a/.vale/styles/RedHat/dictionaries/wordlist.txt
+++ b/.vale/styles/RedHat/dictionaries/wordlist.txt
@@ -3,7 +3,7 @@
 # Source of truth for en_US-RedHat.dic. Run tools/build-dictionary.py
 # to regenerate the dictionary after editing this file.
 #
-# Format: one plain word per line. No special flags needed.
+# Format: one plain text word per line. No special Hunspell flags needed.
 #
 #   - Include both singular and plural forms (e.g., API and APIs).
 #     The build script detects plurals and consolidates them with /S flags.

--- a/.vale/styles/config/actions/NoGerundsInTitles.tengo
+++ b/.vale/styles/config/actions/NoGerundsInTitles.tengo
@@ -1,0 +1,43 @@
+text := import("text")
+
+// suggestions is the script's output
+suggestions := []
+word := match
+
+// Pattern: -ating -> -ate (Validating, Creating, Generating)
+if text.has_suffix(word, "ating") {
+  base := text.trim_suffix(word, "ating")
+  suggestions = append(suggestions, base + "ate")
+}
+
+// Pattern: -aging -> -age (Managing)
+if text.has_suffix(word, "aging") {
+  base := text.trim_suffix(word, "aging")
+  suggestions = append(suggestions, base + "age")
+}
+
+// Pattern: -izing -> -ize (Organizing)
+if text.has_suffix(word, "izing") {
+  base := text.trim_suffix(word, "izing")
+  suggestions = append(suggestions, base + "ize")
+}
+
+// Pattern: -ising -> -ise (Advertising)
+if text.has_suffix(word, "ising") {
+  base := text.trim_suffix(word, "ising")
+  suggestions = append(suggestions, base + "ise")
+}
+
+// Pattern: -uring -> -ure (Configuring)
+if text.has_suffix(word, "uring") {
+  base := text.trim_suffix(word, "uring")
+  suggestions = append(suggestions, base + "ure")
+}
+
+// Default: just remove -ing (Building -> Build)
+if len(suggestions) == 0 {
+  base := text.trim_suffix(word, "ing")
+  suggestions = append(suggestions, base)
+}
+
+suggestions

--- a/.vale/styles/config/actions/NoGerundsInTitles.tengo
+++ b/.vale/styles/config/actions/NoGerundsInTitles.tengo
@@ -1,43 +1,136 @@
 text := import("text")
 
-// suggestions is the script's output
 suggestions := []
 word := match
+lower := text.to_lower(word)
 
-// Pattern: -ating -> -ate (Validating, Creating, Generating)
-if text.has_suffix(word, "ating") {
-  base := text.trim_suffix(word, "ating")
-  suggestions = append(suggestions, base + "ate")
+// Lookup table for verbs where suffix heuristics produce wrong results.
+// Doubled-consonant verbs (strip -ing leaves doubled letter, e.g. Running -> Runn)
+// and silent-e verbs not caught by suffix patterns (e.g. Writing -> Writ).
+lookup := {
+    "running": "run",
+    "getting": "get",
+    "setting": "set",
+    "putting": "put",
+    "planning": "plan",
+    "stopping": "stop",
+    "dropping": "drop",
+    "mapping": "map",
+    "logging": "log",
+    "debugging": "debug",
+    "formatting": "format",
+    "scanning": "scan",
+    "submitting": "submit",
+    "tagging": "tag",
+    "shipping": "ship",
+    "pinning": "pin",
+    "cutting": "cut",
+    "hitting": "hit",
+    "beginning": "begin",
+    "trimming": "trim",
+    "spinning": "spin",
+    "stepping": "step",
+    "wrapping": "wrap",
+    "snapping": "snap",
+    "plugging": "plug",
+    "skipping": "skip",
+    "flagging": "flag",
+    "swapping": "swap",
+    "popping": "pop",
+    "slotting": "slot",
+    "clipping": "clip",
+    "tapping": "tap",
+    "chatting": "chat",
+    "committing": "commit",
+    "occurring": "occur",
+    "referring": "refer",
+    "transferring": "transfer",
+    "deferring": "defer",
+    "preferring": "prefer",
+    "permitting": "permit",
+    "omitting": "omit",
+    "quitting": "quit",
+    "splitting": "split",
+    "sitting": "sit",
+    "plotting": "plot",
+    "spotting": "spot",
+    "betting": "bet",
+    "netting": "net",
+    "writing": "write",
+    "making": "make",
+    "using": "use",
+    "providing": "provide",
+    "upgrading": "upgrade",
+    "including": "include",
+    "excluding": "exclude",
+    "overriding": "override",
+    "guiding": "guide",
+    "deciding": "decide",
+    "taking": "take",
+    "invoking": "invoke",
+    "closing": "close",
+    "browsing": "browse",
+    "composing": "compose",
+    "choosing": "choose",
+    "deleting": "delete",
+    "completing": "complete",
+    "executing": "execute",
+    "defining": "define",
+    "refining": "refine",
+    "combining": "combine",
+    "typing": "type",
+    "shaping": "shape",
+    "piping": "pipe",
+    "changing": "change",
+    "merging": "merge",
+    "purging": "purge",
+    "describing": "describe",
+    "subscribing": "subscribe",
+    "naming": "name",
+    "consuming": "consume",
+    "assuming": "assume",
+    "resuming": "resume",
+    "syncing": "sync",
+    "modeling": "model",
+    "labeling": "label",
+    "leveling": "level",
+    "canceling": "cancel",
+    "traveling": "travel",
+    "channeling": "channel",
+    "signaling": "signal",
+    "tunneling": "tunnel"
 }
 
-// Pattern: -aging -> -age (Managing)
-if text.has_suffix(word, "aging") {
-  base := text.trim_suffix(word, "aging")
-  suggestions = append(suggestions, base + "age")
-}
-
-// Pattern: -izing -> -ize (Organizing)
-if text.has_suffix(word, "izing") {
-  base := text.trim_suffix(word, "izing")
-  suggestions = append(suggestions, base + "ize")
-}
-
-// Pattern: -ising -> -ise (Advertising)
-if text.has_suffix(word, "ising") {
-  base := text.trim_suffix(word, "ising")
-  suggestions = append(suggestions, base + "ise")
-}
-
-// Pattern: -uring -> -ure (Configuring)
-if text.has_suffix(word, "uring") {
-  base := text.trim_suffix(word, "uring")
-  suggestions = append(suggestions, base + "ure")
-}
-
-// Default: just remove -ing (Building -> Build)
-if len(suggestions) == 0 {
-  base := text.trim_suffix(word, "ing")
-  suggestions = append(suggestions, base)
+result := lookup[lower]
+if result != undefined {
+    suggestions = append(suggestions, text.to_upper(result[0:1]) + result[1:])
+} else if text.has_suffix(word, "ating") {
+    base := text.trim_suffix(word, "ating")
+    suggestions = append(suggestions, base + "ate")
+} else if text.has_suffix(word, "aging") {
+    base := text.trim_suffix(word, "aging")
+    suggestions = append(suggestions, base + "age")
+} else if text.has_suffix(word, "izing") {
+    base := text.trim_suffix(word, "izing")
+    suggestions = append(suggestions, base + "ize")
+} else if text.has_suffix(word, "ising") {
+    base := text.trim_suffix(word, "ising")
+    suggestions = append(suggestions, base + "ise")
+} else if text.has_suffix(word, "uring") {
+    base := text.trim_suffix(word, "uring")
+    suggestions = append(suggestions, base + "ure")
+} else if text.has_suffix(word, "ving") {
+    base := text.trim_suffix(word, "ving")
+    suggestions = append(suggestions, base + "ve")
+} else if text.has_suffix(word, "cing") {
+    base := text.trim_suffix(word, "cing")
+    suggestions = append(suggestions, base + "ce")
+} else if text.has_suffix(word, "ling") && !text.has_suffix(word, "lling") {
+    base := text.trim_suffix(word, "ling")
+    suggestions = append(suggestions, base + "le")
+} else {
+    base := text.trim_suffix(word, "ing")
+    suggestions = append(suggestions, base)
 }
 
 suggestions


### PR DESCRIPTION
Red Hat docs guidance is now _not_ to use gerunds in titles, in favor of the imperative form.

This suggestion rule uses a tengo script replace action to suggest a correct replacement.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6ff67414-8848-487c-aa77-3a8956eb4cb6" />
