### PR TITLE
Remove adapter in TermsErrors

### DIFF
--- a/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/TermsErrors/testinvalid.adoc
@@ -7,7 +7,6 @@ ac
 accelerator key
 acknowledgement
 adapter card
-adaptor
 administrate
 adviser
 air wall

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -52,7 +52,6 @@ swap:
   accelerator key: keyboard shortcut
   acknowledgement: acknowledgment
   adapter card: adapter|card
-  adaptor: adapter
   administrate: administer
   adviser: advisor
   air wall: air gap


### PR DESCRIPTION
Rule blocks legitimate use of 'adaptor'. Example: Cloud API Adaptor