### PR TITLE
Remove suggestions for the unsupported MTC attributes

### DIFF
--- a/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testinvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testinvalid.adoc
@@ -37,10 +37,6 @@ logging subsystem for Red Hat OpenShift
 //vale-fixture
 LVM Storage
 //vale-fixture
-Migration Toolkit for Containers
-//vale-fixture
-MTC
-//vale-fixture
 odo
 //vale-fixture
 OpenShift Cluster Manager

--- a/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testvalid.adoc
+++ b/.vale/fixtures/OpenShiftAsciiDoc/SuggestAttribute/testvalid.adoc
@@ -25,8 +25,6 @@
 {logging}
 {lvms-first}
 {lvms}
-{mtc-full}
-{mtc-short}
 {odo-title}
 {cluster-manager}
 {rh-storage}

--- a/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/SuggestAttribute.yml
@@ -55,8 +55,6 @@ swap:
   Logging subsystem for Red Hat OpenShift: "{logging-title-uc}"
   logging subsystem for Red Hat OpenShift: "{logging-title}"
   LVM Storage: "{lvms}"
-  Migration Toolkit for Containers: "{mtc-full}"
-  MTC: "{mtc-short}"
   odo: "{odo-title}"
   OpenShift Cluster Manager: "{cluster-manager}"
   OpenShift Container Platform: "{product-title}"


### PR DESCRIPTION
As stated in [MIG-1877](https://redhat.atlassian.net/browse/MIG-1877), Migration Toolkit for Containers is only supported in OpenShift up to version 4.20. Consequently, [pull request #108725](https://github.com/openshift/openshift-docs/pull/108725) removed the attributes form the corresponding attribute definition files and any references to them from `main`, `enterprise-4.21`, and `enterprise-4.22`. Because of this, I believe the `OpenShiftAsciiDoc.SuggestAttribute` rule should no longer suggest the use of these removed attributes.