### PR TITLE
fix: include Tengo action scripts in RedHat.zip package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           cd .vale/styles
           echo $GITHUB_RUN_NUMBER > version.txt
-          zip -r RedHat.zip RedHat
+          zip -r RedHat.zip RedHat config
           zip -r AsciiDoc.zip AsciiDoc
           zip -r OpenShiftAsciiDoc.zip OpenShiftAsciiDoc
           cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Problem

Since release v664 (Jul 13, 2026), any project using the `RedHat.zip` Vale package fails with:

```
E100: script 'NoGerundsInTitles.tengo' not found
```

The `NoGerundsInTitles.yml` rule references `NoGerundsInTitles.tengo` via its `action` block:

```yaml
action:
  name: suggest
  params:
    - NoGerundsInTitles.tengo
```

But the release workflow only packages the `RedHat/` directory into `RedHat.zip`. The Tengo script lives at `.vale/styles/config/actions/NoGerundsInTitles.tengo`, which is outside `RedHat/` and therefore not included in the ZIP.

## Fix

Include the `config/` directory alongside `RedHat/` when creating `RedHat.zip`, so that Vale can resolve action scripts at the expected path `.vale/styles/config/actions/`.

## Impact

This is a **breaking change fordownstream consumers** of the `RedHat.zip` package that use `releases/latest`. For example, the [eclipse-che/che-docs](https://github.com/eclipse-che/che-docs) CI pipeline has been failing since v664 was released.


Made with [Cursor](https://cursor.com)