### PR TITLE
fix: restore working directory before zipping AsciiDoc packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
           mkdir -p /tmp/RedHat/styles
           cp -r config RedHat /tmp/RedHat/styles/
           cd /tmp && zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHat.zip" RedHat
+          cd "$GITHUB_WORKSPACE/.vale/styles"
           zip -r AsciiDoc.zip AsciiDoc
           zip -r OpenShiftAsciiDoc.zip OpenShiftAsciiDoc
-          cd "$GITHUB_WORKSPACE"
           cd schematron/output
           zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHatSchematronRules.zip" .
           cd "$GITHUB_WORKSPACE/.vale/styles"


### PR DESCRIPTION
The RedHat.zip build (8bf7b01) left the shell in /tmp, so the subsequent AsciiDoc.zip and OpenShiftAsciiDoc.zip commands failed with "Nothing to do" because those directories only exist under $GITHUB_WORKSPACE/.vale/styles.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED