### PR TITLE
fix: fix release workflow zip paths and structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,10 @@ jobs:
           mkdir -p /tmp/RedHat/styles
           cp -r config RedHat /tmp/RedHat/styles/
           cd /tmp && zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHat.zip" RedHat
+          cd "$GITHUB_WORKSPACE/.vale/styles"
           zip -r AsciiDoc.zip AsciiDoc
           zip -r OpenShiftAsciiDoc.zip OpenShiftAsciiDoc
-          cd "$GITHUB_WORKSPACE"
-          cd schematron/output
+          cd "$GITHUB_WORKSPACE/schematron/output"
           zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHatSchematronRules.zip" .
           cd "$GITHUB_WORKSPACE/.vale/styles"
           gh release create v$GITHUB_RUN_NUMBER 'RedHat.zip' 'AsciiDoc.zip' 'OpenShiftAsciiDoc.zip' 'RedHatSchematronRules.zip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           # RedHat package: wrap in styles/ so vale sync installs config/
           mkdir -p /tmp/RedHat/styles
           cp -r config RedHat /tmp/RedHat/styles/
-          cd /tmp && zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHat.zip" RedHat
+          cd /tmp/RedHat && zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHat.zip" styles
           cd "$GITHUB_WORKSPACE/.vale/styles"
           zip -r AsciiDoc.zip AsciiDoc
           zip -r OpenShiftAsciiDoc.zip OpenShiftAsciiDoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           # RedHat package: wrap in styles/ so vale sync installs config/
           mkdir -p /tmp/RedHat/styles
           cp -r config RedHat /tmp/RedHat/styles/
-          cd /tmp/RedHat && zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHat.zip" styles
+          cd /tmp/RedHat/styles && zip -r "$GITHUB_WORKSPACE/.vale/styles/RedHat.zip" config RedHat
           cd "$GITHUB_WORKSPACE/.vale/styles"
           zip -r AsciiDoc.zip AsciiDoc
           zip -r OpenShiftAsciiDoc.zip OpenShiftAsciiDoc


### PR DESCRIPTION
## Summary
- **Broken AsciiDoc/OpenShiftAsciiDoc zips**: the `cd /tmp` for `RedHat.zip` left the shell in `/tmp`, so the subsequent zip commands failed with `zip error: Nothing to do!`
- **Broken Schematron zip**: `cd schematron/output` was relative to `$GITHUB_WORKSPACE` but the CWD had changed — now uses an absolute path
- **Extra nesting in RedHat.zip**: the zip had wrapper directories; now `config/` and `RedHat/` are at the archive root
- **Adds `workflow_dispatch`** trigger so the Release workflow can be tested manually

## Test plan
- [ ] Manually trigger the Release workflow and verify all four zips are created
- [ ] Download `RedHat.zip` and confirm it extracts as `config/` and `RedHat/` at the root (no wrapper directories)
- [ ] Download `AsciiDoc.zip` and `OpenShiftAsciiDoc.zip` and confirm they extract correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)