### PR TITLE
feat: add RedHat.ProcedureStepLimit rule

### DIFF
--- a/.vale/fixtures/RedHat/ProcedureStepLimit/.vale.ini
+++ b/.vale/fixtures/RedHat/ProcedureStepLimit/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `ProcedureStepLimit` rule
+StylesPath = ../../../styles
+MinAlertLevel = suggestion
+[*.adoc]
+RedHat.ProcedureStepLimit = YES

--- a/.vale/fixtures/RedHat/ProcedureStepLimit/testinvalid.adoc
+++ b/.vale/fixtures/RedHat/ProcedureStepLimit/testinvalid.adoc
@@ -1,0 +1,12 @@
+.Procedure
+. Step 1
+. Step 2
+. Step 3
+. Step 4
+. Step 5
+. Step 6
+. Step 7
+. Step 8
+. Step 9
+. Step 10
+. Step 11

--- a/.vale/fixtures/RedHat/ProcedureStepLimit/testvalid.adoc
+++ b/.vale/fixtures/RedHat/ProcedureStepLimit/testvalid.adoc
@@ -1,0 +1,11 @@
+.Procedure
+. Step 1
+. Step 2
+. Step 3
+. Step 4
+. Step 5
+. Step 6
+. Step 7
+. Step 8
+. Step 9
+. Step 10

--- a/.vale/styles/RedHat/ProcedureStepLimit.yml
+++ b/.vale/styles/RedHat/ProcedureStepLimit.yml
@@ -1,0 +1,44 @@
+---
+extends: script
+level: error
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#proceduresteplimit
+message: "Procedure contains more than 10 steps. Split it into multiple procedures or leverage substeps to group related steps. If the procedure contains conditionals, review the preview to ensure all built targets comply with the limit of 10 steps."
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  scope = text.re_replace("(?s) *(\n////.*?////\n)", scope, "")
+  scope += "\n"
+
+  lines := text.split(scope, "\n")
+  count := 0
+  step_positions := []
+  procedure_position := -1
+  position := 0
+  in_procedure := false
+
+  for line in lines {
+    if text.re_match("^\\.Procedure", line) {
+      in_procedure = true
+      procedure_position = position
+    }
+    if text.re_match("^\\.[A-Z]", line) && !text.re_match("^\\.Procedure", line) {
+      in_procedure = false
+    }
+    if in_procedure && text.re_match("^\\. [^\\.]", line) {
+      count += 1
+      step_positions = append(step_positions, position)
+    }
+    position += len(line) + 1
+  }
+
+  if count > 10 {
+    if procedure_position >= 0 {
+      matches = append(matches, {begin: procedure_position, end: procedure_position + 1})
+    }
+    for i := 0; i < count; i++ {
+      step_pos := step_positions[i]
+      matches = append(matches, {begin: step_pos, end: step_pos + 1})
+    }
+  }


### PR DESCRIPTION
Procedures should not include more than 10 steps. The rule I'm proposing reports procedures that contain more than 10 steps. (Substeps are ignored.) Originally created for a project-specific Vale style in https://github.com/theforeman/foreman-documentation/ through https://github.com/theforeman/foreman-documentation/pull/5009

The rule doesn't report a single error for the whole procedure but rather one error for every step in that procedure (so if a procedure has 11 steps, there are 11 errors reported, one for each step). This is because in our project repo, Vale checks are run on the PR diff, and I wanted to make sure the error is displayed no matter which part of the procedure is updated. See https://github.com/theforeman/foreman-documentation/pull/5009#issuecomment-4875040901 for a more detailed explanation.

The rule as such has been tested in https://github.com/theforeman/foreman-documentation/pull/5009 and has been working quite well for our project.

I wasn't sure how to write the test fixture that's required in vale-at-red-hat so be aware that part is pure Claude :)